### PR TITLE
Feature/43-vtk-3D-wall-graphic

### DIFF
--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -454,7 +454,7 @@ class wall_3D(DataGroup):
         movement    How much the component is moved in metres
         direction    Which direction the component is moved [x, y, z]
         component     Bool array of the points of a component
-        wall         Wall object where the wall is copied from, if left empty active 
+        wall         Wall object where the wall is copied from, if left empty active
         wall from filename will be used
 
         @return the new wall data
@@ -462,7 +462,7 @@ class wall_3D(DataGroup):
         rwall = self.read()
 
         #Movement in metres
-        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2)
+        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2) 
 
         rwall['x1x2x3'][component,:] += t*direction[0]
         rwall['y1y2y3'][component,:] += t*direction[1]

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -454,7 +454,7 @@ class wall_3D(DataGroup):
         movement    How much the component is moved in metres
         direction    Which direction the component is moved [x, y, z]
         component     Bool array of the points of a component
-        wall         Wall object where the wall is copied from, if left empty active
+        wall         Wall object where the wall is copied from, if left empty active 
         wall from filename will be used
 
         @return the new wall data
@@ -462,7 +462,7 @@ class wall_3D(DataGroup):
         rwall = self.read()
 
         #Movement in metres
-        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2) 
+        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2)
 
         rwall['x1x2x3'][component,:] += t*direction[0]
         rwall['y1y2y3'][component,:] += t*direction[1]

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -221,35 +221,37 @@ class wall_3D(DataGroup):
         return self.number_of_elements
 
 
-    def noderepresentation(self, filter_wall = None):
+    def noderepresentation(self, w_indices=None):
         """
         Return an array of vertices and indices that define this wall.
-        Inputs:
-            filter_wall : list[int], optional
-                list of of triangle indices for which the node
-                representation is done. [ind1, ind2, ..., indn]
+
+        Parameters
+        ----------
+        w_indices : array_like, optional
+            list of of triangle indices for which the node
+            representation is done i.e. [ind1, ind2, ..., indn].
+
+            Can also be a Boolean array with the same size as the number of
+            wall triangles.
 
         Returns:
-            vertices : float, array_like <br>
-                Triangle vertices in a format [[x1, y1, z1], ..., [xn, yn, zn]]
-                where n is 3 x number of triangles.
-            faces : int, array_like <br>
-                Array of dimension (number of triangles, 4) where each four
-                length array defines a wall elemenet as [number of vertices, i1,
-                i2, i3] where number of vertices is always 3 and i1, i2, and i3
-                define the indices of the vertices in the vertices array.
+        vertices : float, array_like <br>
+            Triangle vertices in a format [[x1, y1, z1], ..., [xn, yn, zn]]
+            where n is 3 x number of triangles.
+        faces : int, array_like <br>
+            Array of dimension (number of triangles, 4) where each four
+            length array defines a wall elemenet as [number of vertices, i1,
+            i2, i3] where number of vertices is always 3 and i1, i2, and i3
+            define the indices of the vertices in the vertices array.
         """
         with self as h5:
-            if filter_wall is None:
-                ntriangle = int(h5["nelements"][:])
-                x1x2x3 = h5["x1x2x3"]
-                y1y2y3 = h5["y1y2y3"]
-                z1z2z3 = h5["z1z2z3"]
-            else:
-                x1x2x3 = h5["x1x2x3"][filter_wall, :]
-                y1y2y3 = h5["y1y2y3"][filter_wall, :]
-                z1z2z3 = h5["z1z2z3"][filter_wall, :]
-                ntriangle = x1x2x3.shape[0]
+            if w_indices is None:
+                w_indices = np.s_[:] 
+
+            x1x2x3 = h5["x1x2x3"][w_indices, :]
+            y1y2y3 = h5["y1y2y3"][w_indices, :]
+            z1z2z3 = h5["z1z2z3"][w_indices, :]
+            ntriangle = x1x2x3.shape[0]
 
             faces     = np.zeros((ntriangle,4), dtype="i8")
             vertices  = np.zeros((ntriangle*3,3), dtype="f8")

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -246,7 +246,7 @@ class wall_3D(DataGroup):
         """
         with self as h5:
             if w_indices is None:
-                w_indices = np.s_[:] 
+                w_indices = np.s_[:]
 
             x1x2x3 = h5["x1x2x3"][w_indices, :]
             y1y2y3 = h5["y1y2y3"][w_indices, :]
@@ -462,7 +462,7 @@ class wall_3D(DataGroup):
         rwall = self.read()
 
         #Movement in metres
-        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2)
+        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2) 
 
         rwall['x1x2x3'][component,:] += t*direction[0]
         rwall['y1y2y3'][component,:] += t*direction[1]

--- a/a5py/routines/plotting.py
+++ b/a5py/routines/plotting.py
@@ -1027,6 +1027,7 @@ def interactive(wallmesh, *args, points=None, orbit=None, data=None, log=False,
 
     p.show()
 
+
 @openfigureifnoaxes(projection=None)
 def loadvsarea(wetted, loads, axes=None):
     """Plot histogram showing minimum load vs area.

--- a/a5py/routines/plotting.py
+++ b/a5py/routines/plotting.py
@@ -1027,7 +1027,6 @@ def interactive(wallmesh, *args, points=None, orbit=None, data=None, log=False,
 
     p.show()
 
-
 @openfigureifnoaxes(projection=None)
 def loadvsarea(wetted, loads, axes=None):
     """Plot histogram showing minimum load vs area.

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -545,7 +545,7 @@ class RunMixin(DistMixin):
             w_indices : array_like, optional
                 List of triangle indecies for which the 3D mesh is made.
 
-            p_ids : list[int], optional
+            p_ids : array_like, optional
                 List of particle ids for which the wall loads are calculated.
 
 

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -471,8 +471,6 @@ class RunMixin(DistMixin):
 
         Parameters
         ----------
-        qnt : str
-            Name of the averaged quantity.
         weights : bool, optional
             Include marker weights to get physical results (otherwise particle
             deposition would be just the number of markers that hit the tile).

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -462,7 +462,7 @@ class RunMixin(DistMixin):
         energy_peak  = np.amax(edepo/area)
         return wetted_total, energy_peak
 
-    def getwall_loads(self, weights=True, particle_filter = None):
+    def getwall_loads(self, weights=True, p_ids=None):
         """Get wall loads and associated quantities.
 
         This method does not return loads on all wall elements (as usually most
@@ -471,6 +471,8 @@ class RunMixin(DistMixin):
 
         Parameters
         ----------
+        qnt : str
+            Name of the averaged quantity.
         weights : bool, optional
             Include marker weights to get physical results (otherwise particle
             deposition would be just the number of markers that hit the tile).
@@ -478,8 +480,8 @@ class RunMixin(DistMixin):
             Dropping weights is useful to check how many markers hit a tile
             which tells us how good the statistics are.
 
-        particle_filter : list[int], optional
-            Calculate wall loads only for the particles with the given indices
+        p_ids : array_like, optional
+            Calculate wall loads only for the particles with the given indices.
 
         Returns
         -------
@@ -495,13 +497,9 @@ class RunMixin(DistMixin):
             Angle of incidence (TODO).
         """
         self._require("_endstate")
-        if particle_filter is None:
-            ids, energy, weight = self.getstate("walltile", "ekin", "weight",
-                                            state="end", endcond="wall")
-        else:
-            ids, energy, weight = self.getstate("walltile", "ekin", "weight",
+        ids, energy, weight = self.getstate("walltile", "ekin", "weight",
                                             state="end", endcond="wall",
-                                            ids = particle_filter)
+                                            ids=p_ids)
         energy.convert_to_units("J")
         eunit = (energy.units * weight.units)
         try:
@@ -541,15 +539,16 @@ class RunMixin(DistMixin):
 
         return wetted, area, edepo, pdepo, iangle
 
-    def getwall_3dmesh(self, wall_filter = None, particle_filter = None):
-        """Return 3D mesh representation of 3D wall and associated loads.
-        Inputs
-        -------
-            wall_filter : list[int], optional
-                List of triangle indecies for which the 3D mesh is made
+    def getwall_3dmesh(self, w_indices=None, p_ids=None):
+        """Return 3D mesh representation of 3D wall and associated loads
 
-            particle_filter : list[int], optional
-                List of particle ids for which the wall loads are calculated
+        Parameters
+        ----------
+            w_indices : array_like, optional
+                List of triangle indecies for which the 3D mesh is made.
+
+            p_ids : list[int], optional
+                List of particle ids for which the wall loads are calculated.
 
 
         Returns
@@ -564,10 +563,10 @@ class RunMixin(DistMixin):
             - "mload" marker load in units of markers
         """
 
-        wallmesh = pv.PolyData( *self.wall.noderepresentation(filter_wall=wall_filter) )
-        ids, area, eload, pload, iangle = self.getwall_loads(particle_filter=particle_filter)
+        wallmesh = pv.PolyData( *self.wall.noderepresentation(w_indices=w_indices) )
+        ids, area, eload, pload, iangle = self.getwall_loads(p_ids=p_ids)
         # get the marker load at each tile
-        _, _, _, mload, _ = self.getwall_loads(weights = False, particle_filter=particle_filter)
+        _, _, _, mload, _ = self.getwall_loads(weights=False, p_ids=p_ids)
         ids = ids - 1 # Convert IDs to indices
 
         #here possible area filter to ids, TBI
@@ -575,8 +574,8 @@ class RunMixin(DistMixin):
         n_tri = self.wall.getNumberOfElements()
 
         wall_f = np.arange(n_tri, dtype=int)
-        if wall_filter is not None:
-            wall_f = wall_f[wall_filter]
+        if w_indices is not None:
+            wall_f = wall_f[w_indices]
 
         eload_tot = np.zeros((n_tri, )) + np.nan
         eload_tot[ids] = eload/area
@@ -1410,8 +1409,8 @@ class RunMixin(DistMixin):
 
     def plotwall_3dstill(self, wallmesh=None, points=None, orbit=None,
                          data=None, log=False, cpos=None, cfoc=None, cang=None,
-                         particle_filter = None, wall_filter = None,
-                         axes=None, cax=None, **kwargs):
+                         p_ids=None, w_indices=None, axes=None, cax=None,
+                         **kwargs):
         """Take a still shot of the mesh and display it using matplotlib
         backend.
 
@@ -1439,10 +1438,10 @@ class RunMixin(DistMixin):
             Camera focal point coordinates [x, y, z].
         cang : array_like, optional
             Camera angle [azimuth, elevation, roll].
-        particle_filter : array_like, optional
-            List of ids of the particles for which the heat load is shown
-        wall filter : array_like, optional
-            List of wall ids which are included in the wall mesh
+        p_ids : array_like, optional
+            List of ids of the particles for which the heat load is shown.
+        w_indices : array_like, optional
+            List of wall indices which are included in the wall mesh.
         axes : :obj:`~matplotlib.axes.Axes`, optional
             The axes where figure is plotted or otherwise new figure is created.
         cax : :obj:`~matplotlib.axes.Axes`, optional
@@ -1451,8 +1450,7 @@ class RunMixin(DistMixin):
             Keyword arguments passed to :obj:`~pyvista.Plotter`.
         """
         if wallmesh is None:
-            wallmesh = self.getwall_3dmesh(wall_filter = wall_filter,
-                                            particle_filter = particle_filter)
+            wallmesh = self.getwall_3dmesh(p_ids=p_ids, w_indices=w_indices)
         if isinstance(points, bool) and points == True:
             points = self.getstate_pointcloud(endcond="wall")
         if orbit is not None:
@@ -1471,8 +1469,7 @@ class RunMixin(DistMixin):
     def plotwall_3dinteractive(self, wallmesh=None, *args, points=None,
                                orbit=None, data=None, log=False,
                                cpos=None, cfoc=None, cang=None,
-                               particle_filter = None, wall_filter = None,
-                               **kwargs):
+                               p_ids=None, w_indices=None, **kwargs):
         """Open vtk window to display interactive view of the wall mesh.
 
         Parameters
@@ -1498,16 +1495,15 @@ class RunMixin(DistMixin):
             Camera focal point coordinates [x, y, z].
         cang : array_like, optional
             Camera angle [azimuth, elevation, roll].
-        particle_filter : array_like, optional
-            List of ids of the particles for which the heat load is shown
-        wall filter : array_like, optional
-            List of wall ids which are included in the wall mesh
+        p_ids : array_like, optional
+            List of ids of the particles for which the heat load is shown.
+        w_indices : array_like, optional
+            List of wall indices which are included in the wall mesh.
         **kwargs
             Keyword arguments passed to :obj:`~pyvista.Plotter`.
         """
         if wallmesh is None:
-            wallmesh = self.getwall_3dmesh(wall_filter = wall_filter,
-                                            particle_filter = particle_filter)
+            wallmesh = self.getwall_3dmesh(p_ids=p_ids, w_indices=w_indices)
         if isinstance(points, bool) and points == True:
             points = self.getstate_pointcloud(endcond="wall")
         if orbit is not None:


### PR DESCRIPTION
Implemented filtering of triangles and particles for wall load graphics. 
Also implemented new data field `mload`, which describes the number of markers hitting each triangle.
The plotting works without any filters, with only a single filter, or with both filters. 


The plotting has been implemented to both `a5.data.active.plotwall_3dstill` and `a5.data.active.plotwall_3dinteractive` methods.

The wall filter can be a list of indices or a boolean array of all wanted triangles.
Particle filter must be a list of particle ids.

Testing and example script of the usage:
```
from a5py import Ascot
import numpy as np
import unyt

a5 = Ascot(file)

h5 = a5.data.wall.active.read()

wall_filter = np.all(h5['x1x2x3'] > 6, axis = 1) # first wall filter to try with

wall_filter = a5.data.wall.active.area() > 0.00001 # second wall filter to try with

ids, ekin, we = a5.data.active.getstate("ids", "ekin", "weight", state='end')
filt = (ekin*we).to('W') > 0.1 * unyt.W #particle filter to try with
particle_filter = ids[filt]

#a5.data.active.plotwall_3dinteractive(cpos=(0,6.9,0), cfoc=(0,7.0,0), cang=(120,0,-90), data="eload", log = True, p_ids=particle_filter, w_indices=wall_filter)
a5.data.active.plotwall_3dstill(cpos=(0,6.9,0), cfoc=(0,7.0,0), cang=(120,0,-90), data="mload", log = True, p_ids=particle_filter, w_indices=wall_filter)
```

Example image of the marker load (=the level of statistics) from filtering out small triangles, and all small power deposition (0.1 < W) particles from ITER fast ion wall load simulation: 
![image](https://github.com/ascot4fusion/ascot5/assets/47065584/cf2021fa-6197-4f26-a563-47f3bbc847c6)

