### PR TITLE
Changed ints to size_ts in diagnostics to support large arrays

### DIFF
--- a/a5py/ascotpy/ascot2py.py
+++ b/a5py/ascotpy/ascot2py.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# TARGET arch is: ['-I/usr/include/hdf5/serial', '-I/usr/lib/gcc/x86_64-linux-gnu/9/include/']
+# TARGET arch is: ['-I/usr/include/hdf5/serial', '-I/usr/lib/gcc/x86_64-linux-gnu/11/include/']
 # WORD_SIZE is: 8
 # POINTER_SIZE is: 8
 # LONGDOUBLE_SIZE is: 16
@@ -315,21 +315,6 @@ struct_c__SA_B_3DS_offload_data._fields_ = [
     ('PADDING_1', ctypes.c_ubyte * 4),
 ]
 
-class struct_c__SA_B_TC_offload_data(Structure):
-    pass
-
-struct_c__SA_B_TC_offload_data._pack_ = 1 # source:False
-struct_c__SA_B_TC_offload_data._fields_ = [
-    ('axisr', ctypes.c_double),
-    ('axisz', ctypes.c_double),
-    ('psival', ctypes.c_double),
-    ('rhoval', ctypes.c_double),
-    ('B', ctypes.c_double * 3),
-    ('dB', ctypes.c_double * 9),
-    ('offload_array_length', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-]
-
 class struct_c__SA_B_2DS_offload_data(Structure):
     pass
 
@@ -372,6 +357,21 @@ struct_c__SA_B_GS_offload_data._fields_ = [
     ('PADDING_1', ctypes.c_ubyte * 4),
 ]
 
+class struct_c__SA_B_TC_offload_data(Structure):
+    pass
+
+struct_c__SA_B_TC_offload_data._pack_ = 1 # source:False
+struct_c__SA_B_TC_offload_data._fields_ = [
+    ('axisr', ctypes.c_double),
+    ('axisz', ctypes.c_double),
+    ('psival', ctypes.c_double),
+    ('rhoval', ctypes.c_double),
+    ('B', ctypes.c_double * 3),
+    ('dB', ctypes.c_double * 9),
+    ('offload_array_length', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+]
+
 struct_c__SA_B_field_offload_data._pack_ = 1 # source:False
 struct_c__SA_B_field_offload_data._fields_ = [
     ('type', B_field_type),
@@ -388,19 +388,6 @@ struct_c__SA_B_field_offload_data._fields_ = [
 B_field_offload_data = struct_c__SA_B_field_offload_data
 class struct_c__SA_B_field_data(Structure):
     pass
-
-class struct_c__SA_B_TC_data(Structure):
-    pass
-
-struct_c__SA_B_TC_data._pack_ = 1 # source:False
-struct_c__SA_B_TC_data._fields_ = [
-    ('axisr', ctypes.c_double),
-    ('axisz', ctypes.c_double),
-    ('psival', ctypes.c_double),
-    ('rhoval', ctypes.c_double),
-    ('B', ctypes.POINTER(ctypes.c_double)),
-    ('dB', ctypes.POINTER(ctypes.c_double)),
-]
 
 class struct_c__SA_B_3DS_data(Structure):
     pass
@@ -469,6 +456,19 @@ struct_c__SA_B_GS_data._fields_ = [
     ('a0', ctypes.c_double),
     ('alpha0', ctypes.c_double),
     ('delta0', ctypes.c_double),
+]
+
+class struct_c__SA_B_TC_data(Structure):
+    pass
+
+struct_c__SA_B_TC_data._pack_ = 1 # source:False
+struct_c__SA_B_TC_data._fields_ = [
+    ('axisr', ctypes.c_double),
+    ('axisz', ctypes.c_double),
+    ('psival', ctypes.c_double),
+    ('rhoval', ctypes.c_double),
+    ('B', ctypes.POINTER(ctypes.c_double)),
+    ('dB', ctypes.POINTER(ctypes.c_double)),
 ]
 
 struct_c__SA_B_field_data._pack_ = 1 # source:False
@@ -1167,91 +1167,6 @@ diag_orb_update_ml.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data), ctype
 class struct_c__SA_diag_offload_data(Structure):
     pass
 
-class struct_c__SA_dist_6D_offload_data(Structure):
-    pass
-
-struct_c__SA_dist_6D_offload_data._pack_ = 1 # source:False
-struct_c__SA_dist_6D_offload_data._fields_ = [
-    ('n_r', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('min_r', ctypes.c_double),
-    ('max_r', ctypes.c_double),
-    ('n_phi', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-    ('min_phi', ctypes.c_double),
-    ('max_phi', ctypes.c_double),
-    ('n_z', ctypes.c_int32),
-    ('PADDING_2', ctypes.c_ubyte * 4),
-    ('min_z', ctypes.c_double),
-    ('max_z', ctypes.c_double),
-    ('n_pr', ctypes.c_int32),
-    ('PADDING_3', ctypes.c_ubyte * 4),
-    ('min_pr', ctypes.c_double),
-    ('max_pr', ctypes.c_double),
-    ('n_pphi', ctypes.c_int32),
-    ('PADDING_4', ctypes.c_ubyte * 4),
-    ('min_pphi', ctypes.c_double),
-    ('max_pphi', ctypes.c_double),
-    ('n_pz', ctypes.c_int32),
-    ('PADDING_5', ctypes.c_ubyte * 4),
-    ('min_pz', ctypes.c_double),
-    ('max_pz', ctypes.c_double),
-    ('n_time', ctypes.c_int32),
-    ('PADDING_6', ctypes.c_ubyte * 4),
-    ('min_time', ctypes.c_double),
-    ('max_time', ctypes.c_double),
-    ('n_q', ctypes.c_int32),
-    ('PADDING_7', ctypes.c_ubyte * 4),
-    ('min_q', ctypes.c_double),
-    ('max_q', ctypes.c_double),
-]
-
-class struct_c__SA_dist_5D_offload_data(Structure):
-    pass
-
-struct_c__SA_dist_5D_offload_data._pack_ = 1 # source:False
-struct_c__SA_dist_5D_offload_data._fields_ = [
-    ('n_r', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('min_r', ctypes.c_double),
-    ('max_r', ctypes.c_double),
-    ('n_phi', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-    ('min_phi', ctypes.c_double),
-    ('max_phi', ctypes.c_double),
-    ('n_z', ctypes.c_int32),
-    ('PADDING_2', ctypes.c_ubyte * 4),
-    ('min_z', ctypes.c_double),
-    ('max_z', ctypes.c_double),
-    ('n_ppara', ctypes.c_int32),
-    ('PADDING_3', ctypes.c_ubyte * 4),
-    ('min_ppara', ctypes.c_double),
-    ('max_ppara', ctypes.c_double),
-    ('n_pperp', ctypes.c_int32),
-    ('PADDING_4', ctypes.c_ubyte * 4),
-    ('min_pperp', ctypes.c_double),
-    ('max_pperp', ctypes.c_double),
-    ('n_time', ctypes.c_int32),
-    ('PADDING_5', ctypes.c_ubyte * 4),
-    ('min_time', ctypes.c_double),
-    ('max_time', ctypes.c_double),
-    ('n_q', ctypes.c_int32),
-    ('PADDING_6', ctypes.c_ubyte * 4),
-    ('min_q', ctypes.c_double),
-    ('max_q', ctypes.c_double),
-]
-
-class struct_c__SA_diag_transcoef_offload_data(Structure):
-    pass
-
-struct_c__SA_diag_transcoef_offload_data._pack_ = 1 # source:False
-struct_c__SA_diag_transcoef_offload_data._fields_ = [
-    ('Nmrk', ctypes.c_int64),
-    ('Navg', ctypes.c_int32),
-    ('recordrho', ctypes.c_int32),
-    ('interval', ctypes.c_double),
-]
-
 class struct_c__SA_dist_rho5D_offload_data(Structure):
     pass
 
@@ -1345,56 +1260,34 @@ struct_c__SA_dist_COM_offload_data._fields_ = [
     ('max_Ptor', ctypes.c_double),
 ]
 
-struct_c__SA_diag_offload_data._pack_ = 1 # source:False
-struct_c__SA_diag_offload_data._fields_ = [
-    ('diagorb_collect', ctypes.c_int32),
-    ('dist5D_collect', ctypes.c_int32),
-    ('dist6D_collect', ctypes.c_int32),
-    ('distrho5D_collect', ctypes.c_int32),
-    ('distrho6D_collect', ctypes.c_int32),
-    ('distCOM_collect', ctypes.c_int32),
-    ('diagtrcof_collect', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('diagorb', diag_orb_offload_data),
-    ('dist5D', struct_c__SA_dist_5D_offload_data),
-    ('dist6D', struct_c__SA_dist_6D_offload_data),
-    ('distrho5D', struct_c__SA_dist_rho5D_offload_data),
-    ('distrho6D', struct_c__SA_dist_rho6D_offload_data),
-    ('distCOM', struct_c__SA_dist_COM_offload_data),
-    ('diagtrcof', struct_c__SA_diag_transcoef_offload_data),
-    ('offload_dist5D_index', ctypes.c_int32),
-    ('offload_dist6D_index', ctypes.c_int32),
-    ('offload_distrho5D_index', ctypes.c_int32),
-    ('offload_distrho6D_index', ctypes.c_int32),
-    ('offload_distCOM_index', ctypes.c_int32),
-    ('offload_diagorb_index', ctypes.c_int32),
-    ('offload_diagtrcof_index', ctypes.c_int32),
-    ('offload_dist_length', ctypes.c_int32),
-    ('offload_array_length', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
+class struct_c__SA_diag_transcoef_offload_data(Structure):
+    pass
+
+struct_c__SA_diag_transcoef_offload_data._pack_ = 1 # source:False
+struct_c__SA_diag_transcoef_offload_data._fields_ = [
+    ('Nmrk', ctypes.c_int64),
+    ('Navg', ctypes.c_int32),
+    ('recordrho', ctypes.c_int32),
+    ('interval', ctypes.c_double),
 ]
 
-diag_offload_data = struct_c__SA_diag_offload_data
-class struct_c__SA_diag_data(Structure):
+class struct_c__SA_dist_6D_offload_data(Structure):
     pass
 
-class struct_c__SA_dist_rho6D_data(Structure):
-    pass
-
-struct_c__SA_dist_rho6D_data._pack_ = 1 # source:False
-struct_c__SA_dist_rho6D_data._fields_ = [
-    ('n_rho', ctypes.c_int32),
+struct_c__SA_dist_6D_offload_data._pack_ = 1 # source:False
+struct_c__SA_dist_6D_offload_data._fields_ = [
+    ('n_r', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
-    ('min_rho', ctypes.c_double),
-    ('max_rho', ctypes.c_double),
-    ('n_theta', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-    ('min_theta', ctypes.c_double),
-    ('max_theta', ctypes.c_double),
+    ('min_r', ctypes.c_double),
+    ('max_r', ctypes.c_double),
     ('n_phi', ctypes.c_int32),
-    ('PADDING_2', ctypes.c_ubyte * 4),
+    ('PADDING_1', ctypes.c_ubyte * 4),
     ('min_phi', ctypes.c_double),
     ('max_phi', ctypes.c_double),
+    ('n_z', ctypes.c_int32),
+    ('PADDING_2', ctypes.c_ubyte * 4),
+    ('min_z', ctypes.c_double),
+    ('max_z', ctypes.c_double),
     ('n_pr', ctypes.c_int32),
     ('PADDING_3', ctypes.c_ubyte * 4),
     ('min_pr', ctypes.c_double),
@@ -1415,25 +1308,74 @@ struct_c__SA_dist_rho6D_data._fields_ = [
     ('PADDING_7', ctypes.c_ubyte * 4),
     ('min_q', ctypes.c_double),
     ('max_q', ctypes.c_double),
-    ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-class struct_c__SA_diag_transcoef_data(Structure):
+class struct_c__SA_dist_5D_offload_data(Structure):
     pass
 
-class struct_diag_transcoef_link(Structure):
-    pass
-
-struct_c__SA_diag_transcoef_data._pack_ = 1 # source:False
-struct_c__SA_diag_transcoef_data._fields_ = [
-    ('Navg', ctypes.c_int32),
-    ('recordrho', ctypes.c_int32),
-    ('interval', ctypes.c_double),
-    ('datapoints', ctypes.POINTER(ctypes.POINTER(struct_diag_transcoef_link))),
-    ('id', ctypes.POINTER(ctypes.c_double)),
-    ('Kcoef', ctypes.POINTER(ctypes.c_double)),
-    ('Dcoef', ctypes.POINTER(ctypes.c_double)),
+struct_c__SA_dist_5D_offload_data._pack_ = 1 # source:False
+struct_c__SA_dist_5D_offload_data._fields_ = [
+    ('n_r', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('min_r', ctypes.c_double),
+    ('max_r', ctypes.c_double),
+    ('n_phi', ctypes.c_int32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+    ('min_phi', ctypes.c_double),
+    ('max_phi', ctypes.c_double),
+    ('n_z', ctypes.c_int32),
+    ('PADDING_2', ctypes.c_ubyte * 4),
+    ('min_z', ctypes.c_double),
+    ('max_z', ctypes.c_double),
+    ('n_ppara', ctypes.c_int32),
+    ('PADDING_3', ctypes.c_ubyte * 4),
+    ('min_ppara', ctypes.c_double),
+    ('max_ppara', ctypes.c_double),
+    ('n_pperp', ctypes.c_int32),
+    ('PADDING_4', ctypes.c_ubyte * 4),
+    ('min_pperp', ctypes.c_double),
+    ('max_pperp', ctypes.c_double),
+    ('n_time', ctypes.c_int32),
+    ('PADDING_5', ctypes.c_ubyte * 4),
+    ('min_time', ctypes.c_double),
+    ('max_time', ctypes.c_double),
+    ('n_q', ctypes.c_int32),
+    ('PADDING_6', ctypes.c_ubyte * 4),
+    ('min_q', ctypes.c_double),
+    ('max_q', ctypes.c_double),
 ]
+
+struct_c__SA_diag_offload_data._pack_ = 1 # source:False
+struct_c__SA_diag_offload_data._fields_ = [
+    ('diagorb_collect', ctypes.c_int32),
+    ('dist5D_collect', ctypes.c_int32),
+    ('dist6D_collect', ctypes.c_int32),
+    ('distrho5D_collect', ctypes.c_int32),
+    ('distrho6D_collect', ctypes.c_int32),
+    ('distCOM_collect', ctypes.c_int32),
+    ('diagtrcof_collect', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('diagorb', diag_orb_offload_data),
+    ('dist5D', struct_c__SA_dist_5D_offload_data),
+    ('dist6D', struct_c__SA_dist_6D_offload_data),
+    ('distrho5D', struct_c__SA_dist_rho5D_offload_data),
+    ('distrho6D', struct_c__SA_dist_rho6D_offload_data),
+    ('distCOM', struct_c__SA_dist_COM_offload_data),
+    ('diagtrcof', struct_c__SA_diag_transcoef_offload_data),
+    ('offload_dist5D_index', ctypes.c_uint64),
+    ('offload_dist6D_index', ctypes.c_uint64),
+    ('offload_distrho5D_index', ctypes.c_uint64),
+    ('offload_distrho6D_index', ctypes.c_uint64),
+    ('offload_distCOM_index', ctypes.c_uint64),
+    ('offload_diagorb_index', ctypes.c_uint64),
+    ('offload_diagtrcof_index', ctypes.c_uint64),
+    ('offload_dist_length', ctypes.c_uint64),
+    ('offload_array_length', ctypes.c_uint64),
+]
+
+diag_offload_data = struct_c__SA_diag_offload_data
+class struct_c__SA_diag_data(Structure):
+    pass
 
 class struct_c__SA_dist_6D_data(Structure):
     pass
@@ -1472,7 +1414,31 @@ struct_c__SA_dist_6D_data._fields_ = [
     ('PADDING_7', ctypes.c_ubyte * 4),
     ('min_q', ctypes.c_double),
     ('max_q', ctypes.c_double),
+    ('step_1', ctypes.c_uint64),
+    ('step_2', ctypes.c_uint64),
+    ('step_3', ctypes.c_uint64),
+    ('step_4', ctypes.c_uint64),
+    ('step_5', ctypes.c_uint64),
+    ('step_6', ctypes.c_uint64),
+    ('step_7', ctypes.c_uint64),
     ('histogram', ctypes.POINTER(ctypes.c_double)),
+]
+
+class struct_c__SA_diag_transcoef_data(Structure):
+    pass
+
+class struct_diag_transcoef_link(Structure):
+    pass
+
+struct_c__SA_diag_transcoef_data._pack_ = 1 # source:False
+struct_c__SA_diag_transcoef_data._fields_ = [
+    ('Navg', ctypes.c_int32),
+    ('recordrho', ctypes.c_int32),
+    ('interval', ctypes.c_double),
+    ('datapoints', ctypes.POINTER(ctypes.POINTER(struct_diag_transcoef_link))),
+    ('id', ctypes.POINTER(ctypes.c_double)),
+    ('Kcoef', ctypes.POINTER(ctypes.c_double)),
+    ('Dcoef', ctypes.POINTER(ctypes.c_double)),
 ]
 
 class struct_c__SA_dist_5D_data(Structure):
@@ -1508,6 +1474,59 @@ struct_c__SA_dist_5D_data._fields_ = [
     ('PADDING_6', ctypes.c_ubyte * 4),
     ('min_q', ctypes.c_double),
     ('max_q', ctypes.c_double),
+    ('step_1', ctypes.c_uint64),
+    ('step_2', ctypes.c_uint64),
+    ('step_3', ctypes.c_uint64),
+    ('step_4', ctypes.c_uint64),
+    ('step_5', ctypes.c_uint64),
+    ('step_6', ctypes.c_uint64),
+    ('histogram', ctypes.POINTER(ctypes.c_double)),
+]
+
+class struct_c__SA_dist_rho6D_data(Structure):
+    pass
+
+struct_c__SA_dist_rho6D_data._pack_ = 1 # source:False
+struct_c__SA_dist_rho6D_data._fields_ = [
+    ('n_rho', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('min_rho', ctypes.c_double),
+    ('max_rho', ctypes.c_double),
+    ('n_theta', ctypes.c_int32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+    ('min_theta', ctypes.c_double),
+    ('max_theta', ctypes.c_double),
+    ('n_phi', ctypes.c_int32),
+    ('PADDING_2', ctypes.c_ubyte * 4),
+    ('min_phi', ctypes.c_double),
+    ('max_phi', ctypes.c_double),
+    ('n_pr', ctypes.c_int32),
+    ('PADDING_3', ctypes.c_ubyte * 4),
+    ('min_pr', ctypes.c_double),
+    ('max_pr', ctypes.c_double),
+    ('n_pphi', ctypes.c_int32),
+    ('PADDING_4', ctypes.c_ubyte * 4),
+    ('min_pphi', ctypes.c_double),
+    ('max_pphi', ctypes.c_double),
+    ('n_pz', ctypes.c_int32),
+    ('PADDING_5', ctypes.c_ubyte * 4),
+    ('min_pz', ctypes.c_double),
+    ('max_pz', ctypes.c_double),
+    ('n_time', ctypes.c_int32),
+    ('PADDING_6', ctypes.c_ubyte * 4),
+    ('min_time', ctypes.c_double),
+    ('max_time', ctypes.c_double),
+    ('n_q', ctypes.c_int32),
+    ('PADDING_7', ctypes.c_ubyte * 4),
+    ('min_q', ctypes.c_double),
+    ('max_q', ctypes.c_double),
+    ('step_1', ctypes.c_uint64),
+    ('step_2', ctypes.c_uint64),
+    ('step_3', ctypes.c_uint64),
+    ('step_4', ctypes.c_uint64),
+    ('step_5', ctypes.c_uint64),
+    ('step_6', ctypes.c_uint64),
+    ('step_7', ctypes.c_uint64),
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
@@ -1528,6 +1547,8 @@ struct_c__SA_dist_COM_data._fields_ = [
     ('PADDING_2', ctypes.c_ubyte * 4),
     ('min_Ptor', ctypes.c_double),
     ('max_Ptor', ctypes.c_double),
+    ('step_1', ctypes.c_uint64),
+    ('step_2', ctypes.c_uint64),
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
@@ -1564,6 +1585,12 @@ struct_c__SA_dist_rho5D_data._fields_ = [
     ('PADDING_6', ctypes.c_ubyte * 4),
     ('min_q', ctypes.c_double),
     ('max_q', ctypes.c_double),
+    ('step_1', ctypes.c_uint64),
+    ('step_2', ctypes.c_uint64),
+    ('step_3', ctypes.c_uint64),
+    ('step_4', ctypes.c_uint64),
+    ('step_5', ctypes.c_uint64),
+    ('step_6', ctypes.c_uint64),
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
@@ -1664,6 +1691,23 @@ class struct_c__SA_sim_offload_data(Structure):
 class struct_c__SA_plasma_offload_data(Structure):
     pass
 
+class struct_c__SA_plasma_1Dt_offload_data(Structure):
+    pass
+
+struct_c__SA_plasma_1Dt_offload_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1Dt_offload_data._fields_ = [
+    ('n_rho', ctypes.c_int32),
+    ('n_time', ctypes.c_int32),
+    ('n_species', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('mass', ctypes.c_double * 8),
+    ('charge', ctypes.c_double * 8),
+    ('anum', ctypes.c_int32 * 8),
+    ('znum', ctypes.c_int32 * 8),
+    ('offload_array_length', ctypes.c_int32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+]
+
 class struct_c__SA_plasma_1DS_offload_data(Structure):
     pass
 
@@ -1709,23 +1753,6 @@ struct_c__SA_plasma_1D_offload_data._fields_ = [
     ('PADDING_0', ctypes.c_ubyte * 4),
 ]
 
-class struct_c__SA_plasma_1Dt_offload_data(Structure):
-    pass
-
-struct_c__SA_plasma_1Dt_offload_data._pack_ = 1 # source:False
-struct_c__SA_plasma_1Dt_offload_data._fields_ = [
-    ('n_rho', ctypes.c_int32),
-    ('n_time', ctypes.c_int32),
-    ('n_species', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('mass', ctypes.c_double * 8),
-    ('charge', ctypes.c_double * 8),
-    ('anum', ctypes.c_int32 * 8),
-    ('znum', ctypes.c_int32 * 8),
-    ('offload_array_length', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-]
-
 struct_c__SA_plasma_offload_data._pack_ = 1 # source:False
 struct_c__SA_plasma_offload_data._fields_ = [
     ('type', plasma_type),
@@ -1739,6 +1766,19 @@ struct_c__SA_plasma_offload_data._fields_ = [
 
 class struct_c__SA_E_field_offload_data(Structure):
     pass
+
+class struct_c__SA_E_1DS_offload_data(Structure):
+    pass
+
+struct_c__SA_E_1DS_offload_data._pack_ = 1 # source:False
+struct_c__SA_E_1DS_offload_data._fields_ = [
+    ('n_rho', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('rho_min', ctypes.c_double),
+    ('rho_max', ctypes.c_double),
+    ('offload_array_length', ctypes.c_int32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+]
 
 class struct_c__SA_E_TC_offload_data(Structure):
     pass
@@ -1759,19 +1799,6 @@ E_field_type__enumvalues = {
 E_field_type_TC = 0
 E_field_type_1DS = 1
 E_field_type = ctypes.c_uint32 # enum
-class struct_c__SA_E_1DS_offload_data(Structure):
-    pass
-
-struct_c__SA_E_1DS_offload_data._pack_ = 1 # source:False
-struct_c__SA_E_1DS_offload_data._fields_ = [
-    ('n_rho', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('rho_min', ctypes.c_double),
-    ('rho_max', ctypes.c_double),
-    ('offload_array_length', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-]
-
 struct_c__SA_E_field_offload_data._pack_ = 1 # source:False
 struct_c__SA_E_field_offload_data._fields_ = [
     ('type', E_field_type),
@@ -1795,30 +1822,6 @@ struct_c__SA_boozer_offload_data._fields_ = [
     ('nthetag', ctypes.c_int32),
     ('nrzs', ctypes.c_int32),
     ('offload_array_length', ctypes.c_int32),
-]
-
-class struct_c__SA_nbi_offload_data(Structure):
-    pass
-
-struct_c__SA_nbi_offload_data._pack_ = 1 # source:False
-struct_c__SA_nbi_offload_data._fields_ = [
-    ('ninj', ctypes.c_int32),
-    ('id', ctypes.c_int32 * 16),
-    ('n_beamlet', ctypes.c_int32 * 16),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('power', ctypes.c_double * 16),
-    ('energy', ctypes.c_double * 16),
-    ('efrac', ctypes.c_double * 48),
-    ('div_h', ctypes.c_double * 16),
-    ('div_v', ctypes.c_double * 16),
-    ('div_halo_frac', ctypes.c_double * 16),
-    ('div_halo_h', ctypes.c_double * 16),
-    ('div_halo_v', ctypes.c_double * 16),
-    ('anum', ctypes.c_int32 * 16),
-    ('znum', ctypes.c_int32 * 16),
-    ('mass', ctypes.c_double * 16),
-    ('offload_array_length', ctypes.c_int32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
 ]
 
 class struct_c__SA_neutral_offload_data(Structure):
@@ -1846,15 +1849,6 @@ struct_c__SA_N0_3D_offload_data._fields_ = [
     ('offload_array_length', ctypes.c_int32),
 ]
 
-
-# values for enumeration 'neutral_type'
-neutral_type__enumvalues = {
-    0: 'neutral_type_1D',
-    1: 'neutral_type_3D',
-}
-neutral_type_1D = 0
-neutral_type_3D = 1
-neutral_type = ctypes.c_uint32 # enum
 class struct_c__SA_N0_1D_offload_data(Structure):
     pass
 
@@ -1871,12 +1865,45 @@ struct_c__SA_N0_1D_offload_data._fields_ = [
     ('offload_array_length', ctypes.c_int32),
 ]
 
+
+# values for enumeration 'neutral_type'
+neutral_type__enumvalues = {
+    0: 'neutral_type_1D',
+    1: 'neutral_type_3D',
+}
+neutral_type_1D = 0
+neutral_type_3D = 1
+neutral_type = ctypes.c_uint32 # enum
 struct_c__SA_neutral_offload_data._pack_ = 1 # source:False
 struct_c__SA_neutral_offload_data._fields_ = [
     ('type', neutral_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('N01D', struct_c__SA_N0_1D_offload_data),
     ('N03D', struct_c__SA_N0_3D_offload_data),
+    ('offload_array_length', ctypes.c_int32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+]
+
+class struct_c__SA_nbi_offload_data(Structure):
+    pass
+
+struct_c__SA_nbi_offload_data._pack_ = 1 # source:False
+struct_c__SA_nbi_offload_data._fields_ = [
+    ('ninj', ctypes.c_int32),
+    ('id', ctypes.c_int32 * 16),
+    ('n_beamlet', ctypes.c_int32 * 16),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('power', ctypes.c_double * 16),
+    ('energy', ctypes.c_double * 16),
+    ('efrac', ctypes.c_double * 48),
+    ('div_h', ctypes.c_double * 16),
+    ('div_v', ctypes.c_double * 16),
+    ('div_halo_frac', ctypes.c_double * 16),
+    ('div_halo_h', ctypes.c_double * 16),
+    ('div_halo_v', ctypes.c_double * 16),
+    ('anum', ctypes.c_int32 * 16),
+    ('znum', ctypes.c_int32 * 16),
+    ('mass', ctypes.c_double * 16),
     ('offload_array_length', ctypes.c_int32),
     ('PADDING_1', ctypes.c_ubyte * 4),
 ]
@@ -2021,6 +2048,189 @@ struct_c__SA_mccc_data._fields_ = [
     ('include_gcdiff', ctypes.c_int32),
 ]
 
+class struct_c__SA_mhd_data(Structure):
+    pass
+
+class struct_c__SA_mhd_stat_data(Structure):
+    pass
+
+struct_c__SA_mhd_stat_data._pack_ = 1 # source:False
+struct_c__SA_mhd_stat_data._fields_ = [
+    ('n_modes', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('rho_min', ctypes.c_double),
+    ('rho_max', ctypes.c_double),
+    ('nmode', ctypes.c_int32 * 512),
+    ('mmode', ctypes.c_int32 * 512),
+    ('amplitude_nm', ctypes.c_double * 512),
+    ('omega_nm', ctypes.c_double * 512),
+    ('phase_nm', ctypes.c_double * 512),
+    ('alpha_nm', struct_c__SA_interp1D_data * 512),
+    ('phi_nm', struct_c__SA_interp1D_data * 512),
+]
+
+class struct_c__SA_mhd_nonstat_data(Structure):
+    pass
+
+struct_c__SA_mhd_nonstat_data._pack_ = 1 # source:False
+struct_c__SA_mhd_nonstat_data._fields_ = [
+    ('n_modes', ctypes.c_int32),
+    ('nmode', ctypes.c_int32 * 512),
+    ('mmode', ctypes.c_int32 * 512),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('amplitude_nm', ctypes.c_double * 512),
+    ('omega_nm', ctypes.c_double * 512),
+    ('phase_nm', ctypes.c_double * 512),
+    ('alpha_nm', struct_c__SA_interp2D_data * 512),
+    ('phi_nm', struct_c__SA_interp2D_data * 512),
+]
+
+struct_c__SA_mhd_data._pack_ = 1 # source:False
+struct_c__SA_mhd_data._fields_ = [
+    ('type', mhd_type),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('stat', struct_c__SA_mhd_stat_data),
+    ('nonstat', struct_c__SA_mhd_nonstat_data),
+]
+
+class struct_c__SA_plasma_data(Structure):
+    pass
+
+class struct_c__SA_plasma_1DS_data(Structure):
+    pass
+
+struct_c__SA_plasma_1DS_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1DS_data._fields_ = [
+    ('n_species', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('mass', ctypes.c_double * 8),
+    ('charge', ctypes.c_double * 8),
+    ('anum', ctypes.c_int32 * 8),
+    ('znum', ctypes.c_int32 * 8),
+    ('temp', struct_c__SA_interp1D_data * 2),
+    ('dens', struct_c__SA_interp1D_data * 8),
+]
+
+class struct_c__SA_plasma_1Dt_data(Structure):
+    pass
+
+struct_c__SA_plasma_1Dt_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1Dt_data._fields_ = [
+    ('n_rho', ctypes.c_int32),
+    ('n_time', ctypes.c_int32),
+    ('n_species', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('mass', ctypes.c_double * 8),
+    ('charge', ctypes.c_double * 8),
+    ('anum', ctypes.c_int32 * 8),
+    ('znum', ctypes.c_int32 * 8),
+    ('rho', ctypes.POINTER(ctypes.c_double)),
+    ('time', ctypes.POINTER(ctypes.c_double)),
+    ('temp', ctypes.POINTER(ctypes.c_double)),
+    ('dens', ctypes.POINTER(ctypes.c_double)),
+]
+
+class struct_c__SA_plasma_1D_data(Structure):
+    pass
+
+struct_c__SA_plasma_1D_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1D_data._fields_ = [
+    ('n_rho', ctypes.c_int32),
+    ('n_species', ctypes.c_int32),
+    ('mass', ctypes.c_double * 8),
+    ('charge', ctypes.c_double * 8),
+    ('anum', ctypes.c_int32 * 8),
+    ('znum', ctypes.c_int32 * 8),
+    ('rho', ctypes.POINTER(ctypes.c_double)),
+    ('temp', ctypes.POINTER(ctypes.c_double)),
+    ('dens', ctypes.POINTER(ctypes.c_double)),
+]
+
+struct_c__SA_plasma_data._pack_ = 1 # source:False
+struct_c__SA_plasma_data._fields_ = [
+    ('type', plasma_type),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('plasma_1D', struct_c__SA_plasma_1D_data),
+    ('plasma_1Dt', struct_c__SA_plasma_1Dt_data),
+    ('plasma_1DS', struct_c__SA_plasma_1DS_data),
+]
+
+class struct_c__SA_E_field_data(Structure):
+    pass
+
+class struct_c__SA_E_1DS_data(Structure):
+    _pack_ = 1 # source:False
+    _fields_ = [
+    ('dV', struct_c__SA_interp1D_data),
+     ]
+
+class struct_c__SA_E_TC_data(Structure):
+    pass
+
+struct_c__SA_E_TC_data._pack_ = 1 # source:False
+struct_c__SA_E_TC_data._fields_ = [
+    ('Exyz', ctypes.POINTER(ctypes.c_double)),
+]
+
+struct_c__SA_E_field_data._pack_ = 1 # source:False
+struct_c__SA_E_field_data._fields_ = [
+    ('type', E_field_type),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('ETC', struct_c__SA_E_TC_data),
+    ('E1DS', struct_c__SA_E_1DS_data),
+]
+
+class struct_c__SA_boozer_data(Structure):
+    pass
+
+struct_c__SA_boozer_data._pack_ = 1 # source:False
+struct_c__SA_boozer_data._fields_ = [
+    ('psi_min', ctypes.c_double),
+    ('psi_max', ctypes.c_double),
+    ('rs', ctypes.POINTER(ctypes.c_double)),
+    ('zs', ctypes.POINTER(ctypes.c_double)),
+    ('nrzs', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('nu_psitheta', struct_c__SA_interp2D_data),
+    ('theta_psithetageom', struct_c__SA_interp2D_data),
+]
+
+class struct_c__SA_nbi_data(Structure):
+    pass
+
+class struct_c__SA_nbi_injector(Structure):
+    pass
+
+struct_c__SA_nbi_injector._pack_ = 1 # source:False
+struct_c__SA_nbi_injector._fields_ = [
+    ('id', ctypes.c_int32),
+    ('n_beamlet', ctypes.c_int32),
+    ('beamlet_x', ctypes.POINTER(ctypes.c_double)),
+    ('beamlet_y', ctypes.POINTER(ctypes.c_double)),
+    ('beamlet_z', ctypes.POINTER(ctypes.c_double)),
+    ('beamlet_dx', ctypes.POINTER(ctypes.c_double)),
+    ('beamlet_dy', ctypes.POINTER(ctypes.c_double)),
+    ('beamlet_dz', ctypes.POINTER(ctypes.c_double)),
+    ('power', ctypes.c_double),
+    ('energy', ctypes.c_double),
+    ('efrac', ctypes.c_double * 3),
+    ('div_h', ctypes.c_double),
+    ('div_v', ctypes.c_double),
+    ('div_halo_frac', ctypes.c_double),
+    ('div_halo_h', ctypes.c_double),
+    ('div_halo_v', ctypes.c_double),
+    ('anum', ctypes.c_int32),
+    ('znum', ctypes.c_int32),
+    ('mass', ctypes.c_double),
+]
+
+struct_c__SA_nbi_data._pack_ = 1 # source:False
+struct_c__SA_nbi_data._fields_ = [
+    ('ninj', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('inj', struct_c__SA_nbi_injector * 16),
+]
+
 class struct_c__SA_neutral_data(Structure):
     pass
 
@@ -2081,189 +2291,6 @@ struct_c__SA_neutral_data._fields_ = [
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('N01D', struct_c__SA_N0_1D_data),
     ('N03D', struct_c__SA_N0_3D_data),
-]
-
-class struct_c__SA_mhd_data(Structure):
-    pass
-
-class struct_c__SA_mhd_stat_data(Structure):
-    pass
-
-struct_c__SA_mhd_stat_data._pack_ = 1 # source:False
-struct_c__SA_mhd_stat_data._fields_ = [
-    ('n_modes', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('rho_min', ctypes.c_double),
-    ('rho_max', ctypes.c_double),
-    ('nmode', ctypes.c_int32 * 512),
-    ('mmode', ctypes.c_int32 * 512),
-    ('amplitude_nm', ctypes.c_double * 512),
-    ('omega_nm', ctypes.c_double * 512),
-    ('phase_nm', ctypes.c_double * 512),
-    ('alpha_nm', struct_c__SA_interp1D_data * 512),
-    ('phi_nm', struct_c__SA_interp1D_data * 512),
-]
-
-class struct_c__SA_mhd_nonstat_data(Structure):
-    pass
-
-struct_c__SA_mhd_nonstat_data._pack_ = 1 # source:False
-struct_c__SA_mhd_nonstat_data._fields_ = [
-    ('n_modes', ctypes.c_int32),
-    ('nmode', ctypes.c_int32 * 512),
-    ('mmode', ctypes.c_int32 * 512),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('amplitude_nm', ctypes.c_double * 512),
-    ('omega_nm', ctypes.c_double * 512),
-    ('phase_nm', ctypes.c_double * 512),
-    ('alpha_nm', struct_c__SA_interp2D_data * 512),
-    ('phi_nm', struct_c__SA_interp2D_data * 512),
-]
-
-struct_c__SA_mhd_data._pack_ = 1 # source:False
-struct_c__SA_mhd_data._fields_ = [
-    ('type', mhd_type),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('stat', struct_c__SA_mhd_stat_data),
-    ('nonstat', struct_c__SA_mhd_nonstat_data),
-]
-
-class struct_c__SA_nbi_data(Structure):
-    pass
-
-class struct_c__SA_nbi_injector(Structure):
-    pass
-
-struct_c__SA_nbi_injector._pack_ = 1 # source:False
-struct_c__SA_nbi_injector._fields_ = [
-    ('id', ctypes.c_int32),
-    ('n_beamlet', ctypes.c_int32),
-    ('beamlet_x', ctypes.POINTER(ctypes.c_double)),
-    ('beamlet_y', ctypes.POINTER(ctypes.c_double)),
-    ('beamlet_z', ctypes.POINTER(ctypes.c_double)),
-    ('beamlet_dx', ctypes.POINTER(ctypes.c_double)),
-    ('beamlet_dy', ctypes.POINTER(ctypes.c_double)),
-    ('beamlet_dz', ctypes.POINTER(ctypes.c_double)),
-    ('power', ctypes.c_double),
-    ('energy', ctypes.c_double),
-    ('efrac', ctypes.c_double * 3),
-    ('div_h', ctypes.c_double),
-    ('div_v', ctypes.c_double),
-    ('div_halo_frac', ctypes.c_double),
-    ('div_halo_h', ctypes.c_double),
-    ('div_halo_v', ctypes.c_double),
-    ('anum', ctypes.c_int32),
-    ('znum', ctypes.c_int32),
-    ('mass', ctypes.c_double),
-]
-
-struct_c__SA_nbi_data._pack_ = 1 # source:False
-struct_c__SA_nbi_data._fields_ = [
-    ('ninj', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('inj', struct_c__SA_nbi_injector * 16),
-]
-
-class struct_c__SA_plasma_data(Structure):
-    pass
-
-class struct_c__SA_plasma_1Dt_data(Structure):
-    pass
-
-struct_c__SA_plasma_1Dt_data._pack_ = 1 # source:False
-struct_c__SA_plasma_1Dt_data._fields_ = [
-    ('n_rho', ctypes.c_int32),
-    ('n_time', ctypes.c_int32),
-    ('n_species', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('mass', ctypes.c_double * 8),
-    ('charge', ctypes.c_double * 8),
-    ('anum', ctypes.c_int32 * 8),
-    ('znum', ctypes.c_int32 * 8),
-    ('rho', ctypes.POINTER(ctypes.c_double)),
-    ('time', ctypes.POINTER(ctypes.c_double)),
-    ('temp', ctypes.POINTER(ctypes.c_double)),
-    ('dens', ctypes.POINTER(ctypes.c_double)),
-]
-
-class struct_c__SA_plasma_1D_data(Structure):
-    pass
-
-struct_c__SA_plasma_1D_data._pack_ = 1 # source:False
-struct_c__SA_plasma_1D_data._fields_ = [
-    ('n_rho', ctypes.c_int32),
-    ('n_species', ctypes.c_int32),
-    ('mass', ctypes.c_double * 8),
-    ('charge', ctypes.c_double * 8),
-    ('anum', ctypes.c_int32 * 8),
-    ('znum', ctypes.c_int32 * 8),
-    ('rho', ctypes.POINTER(ctypes.c_double)),
-    ('temp', ctypes.POINTER(ctypes.c_double)),
-    ('dens', ctypes.POINTER(ctypes.c_double)),
-]
-
-class struct_c__SA_plasma_1DS_data(Structure):
-    pass
-
-struct_c__SA_plasma_1DS_data._pack_ = 1 # source:False
-struct_c__SA_plasma_1DS_data._fields_ = [
-    ('n_species', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('mass', ctypes.c_double * 8),
-    ('charge', ctypes.c_double * 8),
-    ('anum', ctypes.c_int32 * 8),
-    ('znum', ctypes.c_int32 * 8),
-    ('temp', struct_c__SA_interp1D_data * 2),
-    ('dens', struct_c__SA_interp1D_data * 8),
-]
-
-struct_c__SA_plasma_data._pack_ = 1 # source:False
-struct_c__SA_plasma_data._fields_ = [
-    ('type', plasma_type),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('plasma_1D', struct_c__SA_plasma_1D_data),
-    ('plasma_1Dt', struct_c__SA_plasma_1Dt_data),
-    ('plasma_1DS', struct_c__SA_plasma_1DS_data),
-]
-
-class struct_c__SA_E_field_data(Structure):
-    pass
-
-class struct_c__SA_E_1DS_data(Structure):
-    _pack_ = 1 # source:False
-    _fields_ = [
-    ('dV', struct_c__SA_interp1D_data),
-     ]
-
-class struct_c__SA_E_TC_data(Structure):
-    pass
-
-struct_c__SA_E_TC_data._pack_ = 1 # source:False
-struct_c__SA_E_TC_data._fields_ = [
-    ('Exyz', ctypes.POINTER(ctypes.c_double)),
-]
-
-struct_c__SA_E_field_data._pack_ = 1 # source:False
-struct_c__SA_E_field_data._fields_ = [
-    ('type', E_field_type),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('ETC', struct_c__SA_E_TC_data),
-    ('E1DS', struct_c__SA_E_1DS_data),
-]
-
-class struct_c__SA_boozer_data(Structure):
-    pass
-
-struct_c__SA_boozer_data._pack_ = 1 # source:False
-struct_c__SA_boozer_data._fields_ = [
-    ('psi_min', ctypes.c_double),
-    ('psi_max', ctypes.c_double),
-    ('rs', ctypes.POINTER(ctypes.c_double)),
-    ('zs', ctypes.POINTER(ctypes.c_double)),
-    ('nrzs', ctypes.c_int32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
-    ('nu_psitheta', struct_c__SA_interp2D_data),
-    ('theta_psithetageom', struct_c__SA_interp2D_data),
 ]
 
 struct_c__SA_sim_data._pack_ = 1 # source:False

--- a/src/afsi.c
+++ b/src/afsi.c
@@ -154,8 +154,9 @@ void afsi_run(sim_offload_data* sim, Reaction reaction, int n,
                             / ( prod1.max_pperp - prod1.min_pperp ) );
                         prod1.histogram[dist_5D_index(
                                 iR, iphi, iz, ippara, ipperp, 0, 0,
-                                prod1.n_phi, prod1.n_z, prod1.n_ppara,
-                                prod1.n_pperp, 1, 1)] += weight * mult;
+                                prod1.step_6, prod1.step_5, prod1.step_4,
+                                prod1.step_3, prod1.step_2, prod1.step_1)]
+                            += weight * mult;
 
                         ippara = floor(
                             (ppara2[i] - prod2.min_ppara) * prod2.n_ppara
@@ -165,8 +166,9 @@ void afsi_run(sim_offload_data* sim, Reaction reaction, int n,
                             / ( prod2.max_pperp - prod2.min_pperp ) );
                         prod2.histogram[dist_5D_index(
                                 iR, iphi, iz, ippara, ipperp, 0, 0,
-                                prod2.n_phi, prod2.n_z, prod2.n_ppara,
-                                prod2.n_pperp, 1, 1)] += weight * mult;
+                                prod2.step_6, prod2.step_5, prod2.step_4,
+                                prod2.step_3, prod2.step_2, prod2.step_1)]
+                            += weight * mult;
                     }
                 }
                 else {
@@ -416,15 +418,17 @@ void afsi_sample_5D(dist_5D_data* dist, int n, int iR, int iphi, int iz,
     for(int ippara = 0; ippara < dist->n_ppara; ippara++) {
         for(int ipperp = 0; ipperp < dist->n_pperp; ipperp++) {
             if(ippara == 0 && ipperp == 0) {
-                cumdist[0] = dist->histogram[dist_5D_index(iR, iphi, iz,
-                    0, 0, 0, 0, dist->n_phi, dist->n_z, dist->n_ppara,
-                    dist->n_pperp, 1, 1)];
+                cumdist[0] = dist->histogram[dist_5D_index(
+                        iR, iphi, iz, 0, 0, 0, 0, dist->step_6, dist->step_5,
+                        dist->step_4, dist->step_3, dist->step_2,
+                        dist->step_1)];
             } else {
                 cumdist[ippara*dist->n_pperp+ipperp] =
                     cumdist[ippara*dist->n_pperp+ipperp-1]
-                    + dist->histogram[dist_5D_index(iR, iphi, iz,
-                        ippara, ipperp, 0, 0, dist->n_phi, dist->n_z,
-                        dist->n_ppara, dist->n_pperp, 1, 1)];
+                    + dist->histogram[dist_5D_index(
+                        iR, iphi, iz, ippara, ipperp, 0, 0, dist->step_6,
+                        dist->step_5, dist->step_4, dist->step_3, dist->step_2,
+                        dist->step_1)];
             }
         }
     }
@@ -514,10 +518,11 @@ real afsi_get_density(afsi_data* dist, int iR, int iphi, int iz) {
         real density = 0.0;
         for(int ippara = 0; ippara < dist->dist_5D->n_ppara; ippara++) {
             for(int ipperp = 0; ipperp < dist->dist_5D->n_pperp; ipperp++) {
-                density += dist->dist_5D->histogram[dist_5D_index(iR, iphi, iz,
-                           ippara, ipperp, 0, 0, dist->dist_5D->n_phi,
-                           dist->dist_5D->n_z, dist->dist_5D->n_ppara,
-                           dist->dist_5D->n_pperp, 1, 1)] / vol;
+                density += dist->dist_5D->histogram[dist_5D_index(
+                        iR, iphi, iz, ippara, ipperp, 0, 0,
+                        dist->dist_5D->step_6, dist->dist_5D->step_5,
+                        dist->dist_5D->step_4, dist->dist_5D->step_3,
+                        dist->dist_5D->step_2, dist->dist_5D->step_1)] / vol;
             }
         }
         return density;

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -98,7 +98,13 @@ int main(int argc, char** argv) {
     }
 
     /* Initialize diagnostics */
-    diag_init_offload(&sim.diag_offload_data, &diag_offload_array, 0);
+    if( diag_init_offload(&sim.diag_offload_data, &diag_offload_array, 0) ) {
+        print_out0(VERBOSE_MINIMAL, mpi_rank,
+                       "\nFailed to initialize diagnostics.\n"
+                       "See stderr for details.\n");
+            abort();
+            return 1;
+    }
     real diag_offload_array_size = sim.diag_offload_data.offload_array_length
         * sizeof(real) / (1024.0*1024.0);
     print_out0(VERBOSE_IO, mpi_rank,
@@ -228,6 +234,7 @@ int main(int argc, char** argv) {
  * @param t0 time when the injector is turned on
  * @param t1 time when the injector is turned off
  * @param inj pointer to injector data
+ * @param sim pointer to the sim struct with initialized data
  */
 void bbnbi_inject(particle_state* p, int nprt, int ngenerated, real t0, real t1,
                   nbi_injector* inj, sim_data* sim) {
@@ -293,14 +300,11 @@ void bbnbi_inject(particle_state* p, int nprt, int ngenerated, real t0, real t1,
 /**
  * @brief Trace a neutral marker until it has ionized or hit wall
  *
- * This function is for the most part identical to simulate_fo, with few
+ * This function is for the most part identical to simulate_fo with few
  * exceptions relevant for BBNBI.
  *
- * @param p
- * @param Bdata pointer to magnetic field data
- * @param plsdata pointer to plasma data
- * @param walldata pointer to wall data
- * @param rng pointer to random number generator data
+ * @param pq pointer to the marker queue containing the initial neutrals
+ * @param sim pointer to the simu struct with initialized data
  */
 void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
     int cycle[NSIMD]  __memalign__;

--- a/src/diag.c
+++ b/src/diag.c
@@ -26,7 +26,7 @@
 #include "diag/diag_transcoef.h"
 #include "particle.h"
 
-void diag_arraysum(int start, int stop, real* array1, real* array2);
+void diag_arraysum(size_t start, size_t stop, real* array1, real* array2);
 
 /**
  * @brief Initializes offload array from offload data
@@ -39,43 +39,44 @@ void diag_arraysum(int start, int stop, real* array1, real* array2);
  */
 int diag_init_offload(diag_offload_data* data, real** offload_array, int Nmrk){
     /* Determine how long array we need and allocate it */
-    int n = 0;
+    size_t n = 0;
 
     if(data->dist5D_collect) {
         data->offload_dist5D_index = n;
-        n += data->dist5D.n_r * data->dist5D.n_phi * data->dist5D.n_z
-            * data->dist5D.n_ppara * data->dist5D.n_pperp
-            * data->dist5D.n_time * data->dist5D.n_q;
+        n += (size_t)(data->dist5D.n_r)     * (size_t)(data->dist5D.n_phi)
+           * (size_t)(data->dist5D.n_z)     * (size_t)(data->dist5D.n_ppara)
+           * (size_t)(data->dist5D.n_pperp) * (size_t)(data->dist5D.n_time)
+           * (size_t)(data->dist5D.n_q);
     }
 
     if(data->dist6D_collect) {
         data->offload_dist6D_index = n;
-        n += data->dist6D.n_r * data->dist6D.n_phi * data->dist6D.n_z
-             * data->dist6D.n_pr * data->dist6D.n_pphi
-             * data->dist6D.n_pz * data->dist6D.n_time * data->dist6D.n_q;
+        n += (size_t)(data->dist6D.n_r)    * (size_t)(data->dist6D.n_phi)
+           * (size_t)(data->dist6D.n_z)    * (size_t)(data->dist6D.n_pr)
+           * (size_t)(data->dist6D.n_pphi) * (size_t)(data->dist6D.n_pz)
+           * (size_t)(data->dist6D.n_time) * (size_t)(data->dist6D.n_q);
     }
 
     if(data->distrho5D_collect) {
         data->offload_distrho5D_index = n;
-        n += data->distrho5D.n_rho * data->distrho5D.n_theta
-            * data->distrho5D.n_phi
-            * data->distrho5D.n_ppara * data->distrho5D.n_pperp
-            * data->distrho5D.n_time * data->distrho5D.n_q;
+        n += (size_t)(data->distrho5D.n_rho) * (size_t)(data->distrho5D.n_theta)
+           * (size_t)(data->distrho5D.n_phi) * (size_t)(data->distrho5D.n_ppara)
+           * (size_t)(data->distrho5D.n_pperp)
+           * (size_t)(data->distrho5D.n_time) * (size_t)(data->distrho5D.n_q);
     }
 
     if(data->distrho6D_collect) {
         data->offload_distrho6D_index = n;
-        n += data->distrho6D.n_rho * data->distrho6D.n_theta
-            * data->distrho6D.n_phi
-            * data->distrho6D.n_pr * data->distrho6D.n_pphi
-            * data->distrho6D.n_pz * data->distrho6D.n_time
-            * data->distrho6D.n_q;
+        n += (size_t)(data->distrho6D.n_rho) * (size_t)(data->distrho6D.n_theta)
+           * (size_t)(data->distrho6D.n_phi) * (size_t)(data->distrho6D.n_pr)
+           * (size_t)(data->distrho6D.n_pphi) * (size_t)(data->distrho6D.n_pz)
+           * (size_t)(data->distrho6D.n_time) * (size_t)(data->distrho6D.n_q);
     }
 
     if(data->distCOM_collect) {
         data->offload_distCOM_index = n;
-        n += data->distCOM.n_mu * data->distCOM.n_Ekin
-            * data->distCOM.n_Ptor;
+        n += (size_t)(data->distCOM.n_mu) * (size_t)(data->distCOM.n_Ekin)
+            * (size_t)(data->distCOM.n_Ptor);
     }
 
     data->offload_dist_length = n;
@@ -105,19 +106,19 @@ int diag_init_offload(diag_offload_data* data, real** offload_array, int Nmrk){
         }
 
         if(data->diagorb.mode == DIAG_ORB_POINCARE) {
-            n += (data->diagorb.Nfld+2)
-                * data->diagorb.Nmrk * data->diagorb.Npnt;
+            n += (size_t)(data->diagorb.Nfld+2)
+                * (size_t)(data->diagorb.Nmrk) * (size_t)(data->diagorb.Npnt);
         }
         else if(data->diagorb.mode == DIAG_ORB_INTERVAL) {
-            n += data->diagorb.Nfld
-                * data->diagorb.Nmrk * data->diagorb.Npnt;
+            n += (size_t)(data->diagorb.Nfld)
+                * (size_t)(data->diagorb.Nmrk) * (size_t)(data->diagorb.Npnt);
         }
     }
 
     if(data->diagtrcof_collect) {
         data->offload_diagtrcof_index = n;
         data->diagtrcof.Nmrk = Nmrk;
-        n += 3*data->diagtrcof.Nmrk;
+        n += (size_t)(3*data->diagtrcof.Nmrk);
     }
 
     data->offload_array_length = n;
@@ -328,9 +329,9 @@ void diag_update_ml(diag_data* data, particle_simd_ml* p_f,
  */
 void diag_sum(diag_offload_data* data, real* array1, real* array2) {
     if(data->diagorb_collect) {
-        int arr_start = data->offload_diagorb_index;
-        int arr_length = data->diagorb.Nfld * data->diagorb.Nmrk
-            * data->diagorb.Npnt;
+        size_t arr_start = data->offload_diagorb_index;
+        size_t arr_length = (size_t)(data->diagorb.Nfld)
+            * (size_t)(data->diagorb.Nmrk) * (size_t)(data->diagorb.Npnt);
 
         memcpy(&(array1[arr_start+arr_length]),
                &(array2[arr_start]),
@@ -338,8 +339,8 @@ void diag_sum(diag_offload_data* data, real* array1, real* array2) {
     }
 
     if(data->diagtrcof_collect) {
-        int arr_start = data->offload_diagtrcof_index;
-        int arr_length = 3 * data->diagtrcof.Nmrk;
+        size_t arr_start = data->offload_diagtrcof_index;
+        size_t arr_length = (size_t)(3 * data->diagtrcof.Nmrk);
 
         memcpy(&(array1[arr_start+arr_length]),
                &(array2[arr_start]),
@@ -347,43 +348,50 @@ void diag_sum(diag_offload_data* data, real* array1, real* array2) {
     }
 
     if(data->dist5D_collect){
-        int start = data->offload_dist5D_index;
-        int stop = start + data->dist5D.n_r * data->dist5D.n_z
-                   * data->dist5D.n_ppara * data->dist5D.n_pperp
-                   * data->dist5D.n_time * data->dist5D.n_q;
+        size_t start = data->offload_dist5D_index;
+        size_t stop = start + (size_t)(data->dist5D.n_r)
+            * (size_t)(data->dist5D.n_z) * (size_t)(data->dist5D.n_ppara)
+            * (size_t)(data->dist5D.n_pperp) * (size_t)(data->dist5D.n_time)
+            * (size_t)(data->dist5D.n_q);
         diag_arraysum(start, stop, array1, array2);
     }
 
     if(data->dist6D_collect){
-        int start = data->offload_dist6D_index;
-        int stop = start + data->dist6D.n_r * data->dist6D.n_phi
-            * data->dist6D.n_z * data->dist6D.n_pr * data->dist6D.n_pphi
-            * data->dist6D.n_pz * data->dist6D.n_time * data->dist6D.n_q;
+        size_t start = data->offload_dist6D_index;
+        size_t stop = start + (size_t)(data->dist6D.n_r)
+            * (size_t)(data->dist6D.n_phi)
+            * (size_t)(data->dist6D.n_z) * (size_t)(data->dist6D.n_pr)
+            * (size_t)(data->dist6D.n_pphi) * (size_t)(data->dist6D.n_pz)
+            * (size_t)(data->dist6D.n_time) * (size_t)(data->dist6D.n_q);
         diag_arraysum(start, stop, array1, array2);
     }
 
     if(data->distrho5D_collect){
-        int start = data->offload_distrho5D_index;
-        int stop = start + data->distrho5D.n_rho * data->distrho5D.n_theta
-            * data->distrho5D.n_phi * data->distrho5D.n_ppara
-            * data->distrho5D.n_pperp * data->distrho5D.n_time
-            * data->distrho5D.n_q;
+        size_t start = data->offload_distrho5D_index;
+        size_t stop = start + (size_t)(data->distrho5D.n_rho)
+            * (size_t)(data->distrho5D.n_theta)
+            * (size_t)(data->distrho5D.n_phi)
+            * (size_t)(data->distrho5D.n_ppara)
+            * (size_t)(data->distrho5D.n_pperp)
+            * (size_t)(data->distrho5D.n_time)
+            * (size_t)(data->distrho5D.n_q);
         diag_arraysum(start, stop, array1, array2);
     }
 
     if(data->distrho6D_collect){
-        int start = data->offload_distrho6D_index;
-        int stop = start + data->distrho6D.n_rho * data->distrho6D.n_theta
-            * data->distrho6D.n_phi * data->distrho6D.n_pr
-            * data->distrho6D.n_pphi * data->distrho6D.n_pz
-            * data->distrho6D.n_time * data->distrho6D.n_q;
+        size_t start = data->offload_distrho6D_index;
+        size_t stop = start + (size_t)(data->distrho6D.n_rho)
+            * (size_t)(data->distrho6D.n_theta)
+            * (size_t)(data->distrho6D.n_phi)  * (size_t)(data->distrho6D.n_pr)
+            * (size_t)(data->distrho6D.n_pphi) * (size_t)(data->distrho6D.n_pz)
+            * (size_t)(data->distrho6D.n_time) * (size_t)(data->distrho6D.n_q);
         diag_arraysum(start, stop, array1, array2);
     }
 
     if(data->distCOM_collect){
-        int start = data->offload_distCOM_index;
-        int stop = start + data->distCOM.n_mu * data->distCOM.n_Ekin
-            * data->distCOM.n_Ptor;
+        size_t start = data->offload_distCOM_index;
+        size_t stop = start + (size_t)(data->distCOM.n_mu)
+            * (size_t)(data->distCOM.n_Ekin) * (size_t)(data->distCOM.n_Ptor);
         diag_arraysum(start, stop, array1, array2);
     }
 }
@@ -399,8 +407,8 @@ void diag_sum(diag_offload_data* data, real* array1, real* array2) {
  * @param array1 pointer to array where array2 is summed to
  * @param array2 pointer to array which is to be summed
  */
-void diag_arraysum(int start, int stop, real* array1, real* array2) {
-    for(int i = start; i < stop; i++) {
+void diag_arraysum(size_t start, size_t stop, real* array1, real* array2) {
+    for(size_t i = start; i < stop; i++) {
         array1[i] += array2[i];
     }
 }

--- a/src/diag.h
+++ b/src/diag.h
@@ -35,16 +35,16 @@ typedef struct {
     dist_COM_offload_data distCOM;     /**< COM distribution offload data    */
     diag_transcoef_offload_data diagtrcof; /**< Transp. Coef. offload data   */
 
-    int offload_dist5D_index;    /**< Index for 5D dist in offload array     */
-    int offload_dist6D_index;    /**< Index for 5D dist in offload array     */
-    int offload_distrho5D_index; /**< Index for 5D dist in offload array     */
-    int offload_distrho6D_index; /**< Index for 6D rho dist in offload array */
-    int offload_distCOM_index;   /**< Index for COM dist in offload array    */
-    int offload_diagorb_index;   /**< Index for orbit data in offload array  */
-    int offload_diagtrcof_index; /**< Index for trcoef data in offload array */
+    size_t offload_dist5D_index;   /**< Index for 5D dist in offload array    */
+    size_t offload_dist6D_index;   /**< Index for 5D dist in offload array    */
+    size_t offload_distrho5D_index;/**< Index for 5D dist in offload array    */
+    size_t offload_distrho6D_index;/**< Index for 6D rho dist in offload array*/
+    size_t offload_distCOM_index;  /**< Index for COM dist in offload array   */
+    size_t offload_diagorb_index;  /**< Index for orbit data in offload array */
+    size_t offload_diagtrcof_index;/**< Index for trcoef data in offload array*/
 
-    int offload_dist_length;     /**< Number of elements in distributions    */
-    int offload_array_length;    /**< Number of elements in offload_array    */
+    size_t offload_dist_length;    /**< Number of elements in distributions   */
+    size_t offload_array_length;   /**< Number of elements in offload_array   */
 
 } diag_offload_data;
 

--- a/src/diag/dist_5D.c
+++ b/src/diag/dist_5D.c
@@ -12,20 +12,20 @@
 #include "../particle.h"
 
 /**
- * @brief Internal function calculating the index in the histogram array
+ * @brief Function for calculating the index in the histogram array
  */
 #pragma omp declare target
-unsigned long dist_5D_index(int i_r, int i_phi, int i_z, int i_ppara,
-                            int i_pperp, int i_time, int i_q, int n_phi,
-                            int n_z, int n_ppara, int n_pperp, int n_time,
-                            int n_q) {
-    return i_r    * (n_phi * n_z * n_ppara * n_pperp * n_time * n_q)
-        + i_phi   * (n_z * n_ppara * n_pperp * n_time * n_q)
-        + i_z     * (n_ppara * n_pperp * n_time * n_q)
-        + i_ppara * (n_pperp * n_time * n_q)
-        + i_pperp * (n_time * n_q)
-        + i_time  * (n_q)
-        + i_q;
+size_t dist_5D_index(int i_r, int i_phi, int i_z, int i_ppara, int i_pperp,
+                     int i_time, int i_q, size_t step_6, size_t step_5,
+                     size_t step_4, size_t step_3, size_t step_2,
+                     size_t step_1) {
+    return (size_t)(i_r)     * step_6
+         + (size_t)(i_phi)   * step_5
+         + (size_t)(i_z)     * step_4
+         + (size_t)(i_ppara) * step_3
+         + (size_t)(i_pperp) * step_2
+         + (size_t)(i_time)  * step_1
+         + (size_t)(i_q);
 }
 #pragma omp end declare target
 
@@ -88,6 +88,19 @@ void dist_5D_init(dist_5D_data* dist_data, dist_5D_offload_data* offload_data,
     dist_data->n_q       = offload_data->n_q;
     dist_data->min_q     = offload_data->min_q;
     dist_data->max_q     = offload_data->max_q;
+
+    size_t n_q     = (size_t)(dist_data->n_q);
+    size_t n_time  = (size_t)(dist_data->n_time);
+    size_t n_pperp = (size_t)(dist_data->n_pperp);
+    size_t n_ppara = (size_t)(dist_data->n_ppara);
+    size_t n_z     = (size_t)(dist_data->n_z);
+    size_t n_phi   = (size_t)(dist_data->n_phi);
+    dist_data->step_6 = n_q * n_time * n_pperp * n_ppara * n_z * n_phi;
+    dist_data->step_5 = n_q * n_time * n_pperp * n_ppara * n_z;
+    dist_data->step_4 = n_q * n_time * n_pperp * n_ppara;
+    dist_data->step_3 = n_q * n_time * n_pperp;
+    dist_data->step_2 = n_q * n_time;
+    dist_data->step_1 = n_q;
 
     dist_data->histogram = &offload_array[0];
 }
@@ -177,12 +190,10 @@ void dist_5D_update_fo(dist_5D_data* dist, particle_simd_fo* p_f,
 
     for(int i = 0; i < NSIMD; i++) {
         if(p_f->running[i] && ok[i]) {
-            unsigned long index = dist_5D_index(i_r[i], i_phi[i], i_z[i],
-                                                i_ppara[i], i_pperp[i],
-                                                i_time[i], i_q[i],
-                                                dist->n_phi, dist->n_z,
-                                                dist->n_ppara, dist->n_pperp,
-                                                dist->n_time, dist->n_q);
+            size_t index = dist_5D_index(
+                i_r[i], i_phi[i], i_z[i], i_ppara[i], i_pperp[i], i_time[i],
+                i_q[i], dist->step_6, dist->step_5, dist->step_4,
+                dist->step_3, dist->step_2, dist->step_1);
             #pragma omp atomic
             dist->histogram[index] += weight[i];
         }
@@ -266,13 +277,10 @@ void dist_5D_update_gc(dist_5D_data* dist, particle_simd_gc* p_f,
 
     for(int i = 0; i < NSIMD; i++) {
         if(p_f->running[i] && ok[i]) {
-            unsigned long index = dist_5D_index(i_r[i], i_phi[i], i_z[i],
-                                                i_ppara[i], i_pperp[i],
-                                                i_time[i], i_q[i],
-                                                dist->n_phi,  dist->n_z,
-                                                dist->n_ppara, dist->n_pperp,
-                                                dist->n_time, dist->n_q);
-
+            size_t index = dist_5D_index(
+                i_r[i], i_phi[i], i_z[i], i_ppara[i], i_pperp[i], i_time[i],
+                i_q[i], dist->step_6, dist->step_5, dist->step_4,
+                dist->step_3, dist->step_2, dist->step_1);
             #pragma omp atomic
             dist->histogram[index] += weight[i];
         }

--- a/src/diag/dist_5D.h
+++ b/src/diag/dist_5D.h
@@ -5,6 +5,7 @@
 #ifndef DIST_5D_H
 #define DIST_5D_H
 
+#include <stdlib.h>
 #include "../ascot5.h"
 #include "../particle.h"
 
@@ -73,14 +74,21 @@ typedef struct {
     real min_q;       /**< value of lowest r bin                */
     real max_q;       /**< value of highest r bin               */
 
+    size_t step_1;    /**< step for 2nd fastest running index   */
+    size_t step_2;    /**< step for 3rd fastest running index   */
+    size_t step_3;    /**< step for 4th fastest running index   */
+    size_t step_4;    /**< step for 5th fastest running index   */
+    size_t step_5;    /**< step for 6th fastest running index   */
+    size_t step_6;    /**< step for 7th fastest running index   */
+
     real* histogram;  /**< pointer to start of histogram array */
 } dist_5D_data;
 
 #pragma omp declare target
-unsigned long dist_5D_index(int i_r, int i_phi, int i_z, int i_ppara,
-                            int i_pperp, int i_time, int i_q, int n_phi,
-                            int n_z, int n_ppara, int n_pperp, int n_time,
-                            int n_q);
+size_t dist_5D_index(int i_r, int i_phi, int i_z, int i_ppara, int i_pperp,
+                     int i_time, int i_q, size_t step_6, size_t step_5,
+                     size_t step_4, size_t step_3, size_t step_2,
+                     size_t step_1);
 void dist_5D_init(dist_5D_data* dist_data,
                   dist_5D_offload_data* offload_data,
                   real* offload_array);

--- a/src/diag/dist_6D.c
+++ b/src/diag/dist_6D.c
@@ -15,18 +15,18 @@
  * @brief Internal function calculating the index in the histogram array
  */
 #pragma omp declare target
-unsigned long dist_6D_index(int i_r, int i_phi, int i_z, int i_pr, int i_pphi,
-                            int i_pz, int i_time, int i_q, int n_phi, int n_z,
-                            int n_pr, int n_pphi, int n_pz, int n_time,
-                            int n_q) {
-    return i_r    * (n_phi * n_z * n_pr * n_pphi * n_pz * n_time * n_q)
-        + i_phi  * (n_z * n_pr * n_pphi * n_pz * n_time * n_q)
-        + i_z    * (n_pr * n_pphi * n_pz * n_time * n_q)
-        + i_pr   * (n_pphi * n_pz * n_time * n_q)
-        + i_pphi * (n_pz * n_time * n_q)
-        + i_pz   * (n_time * n_q)
-        + i_time * (n_q)
-        + i_q;
+size_t dist_6D_index(int i_r, int i_phi, int i_z, int i_pr, int i_pphi,
+                     int i_pz, int i_time, int i_q, size_t step_7,
+                     size_t step_6, size_t step_5, size_t step_4, size_t step_3,
+                     size_t step_2, size_t step_1) {
+    return (size_t)(i_r)    * step_7
+         + (size_t)(i_phi)  * step_6
+         + (size_t)(i_z)    * step_5
+         + (size_t)(i_pr)   * step_4
+         + (size_t)(i_pphi) * step_3
+         + (size_t)(i_pz)   * step_2
+         + (size_t)(i_time) * step_1
+         + (size_t)(i_q);
 }
 #pragma omp end declare target
 
@@ -90,6 +90,21 @@ void dist_6D_init(dist_6D_data* dist_data, dist_6D_offload_data* offload_data,
     dist_data->n_q      = offload_data->n_q;
     dist_data->min_q    = offload_data->min_q;
     dist_data->max_q    = offload_data->max_q;
+
+    size_t n_q    = (size_t)(dist_data->n_q);
+    size_t n_time = (size_t)(dist_data->n_time);
+    size_t n_pz   = (size_t)(dist_data->n_pz);
+    size_t n_pphi = (size_t)(dist_data->n_pphi);
+    size_t n_pr   = (size_t)(dist_data->n_pr);
+    size_t n_z    = (size_t)(dist_data->n_z);
+    size_t n_phi  = (size_t)(dist_data->n_phi);
+    dist_data->step_7 = n_q * n_time * n_pz * n_pphi * n_pr * n_z * n_phi;
+    dist_data->step_6 = n_q * n_time * n_pz * n_pphi * n_pr * n_z;
+    dist_data->step_5 = n_q * n_time * n_pz * n_pphi * n_pr;
+    dist_data->step_4 = n_q * n_time * n_pz * n_pphi;
+    dist_data->step_3 = n_q * n_time * n_pz;
+    dist_data->step_2 = n_q * n_time;
+    dist_data->step_1 = n_q;
 
     dist_data->histogram = &offload_array[0];
 }
@@ -172,13 +187,10 @@ void dist_6D_update_fo(dist_6D_data* dist, particle_simd_fo* p_f,
 
     for(int i = 0; i < NSIMD; i++) {
         if(p_f->running[i] && ok[i]) {
-            unsigned long index = dist_6D_index(i_r[i], i_phi[i], i_z[i],
-                                                i_pr[i], i_pphi[i], i_pz[i],
-                                                i_time[i], i_q[i],
-                                                dist->n_phi, dist->n_z,
-                                                dist->n_pr, dist->n_pphi,
-                                                dist->n_pz, dist->n_time,
-                                                dist->n_q);
+            size_t index = dist_6D_index(
+                i_r[i], i_phi[i], i_z[i], i_pr[i], i_pphi[i], i_pz[i],
+                i_time[i], i_q[i], dist->step_7, dist->step_6, dist->step_5,
+                dist->step_4, dist->step_3, dist->step_2, dist->step_1);
             #pragma omp atomic
             dist->histogram[index] += weight[i];
         }
@@ -217,18 +229,11 @@ void dist_6D_update_gc(dist_6D_data* dist, particle_simd_gc* p_f,
         if(p_f->running[i]) {
 
             real pr, pphi, pz;
-            real B_dB[12] = {p_f->B_r[i],
-                             p_f->B_r_dr[i],
-                             p_f->B_r_dphi[i],
-                             p_f->B_r_dz[i],
-                             p_f->B_phi[i],
-                             p_f->B_phi_dr[i],
-                             p_f->B_phi_dphi[i],
-                             p_f->B_phi_dz[i],
-                             p_f->B_z[i],
-                             p_f->B_z_dr[i],
-                             p_f->B_z_dphi[i],
-                             p_f->B_z_dz[i]};
+            real B_dB[12] = {
+                p_f->B_r[i], p_f->B_r_dr[i], p_f->B_r_dphi[i], p_f->B_r_dz[i],
+                p_f->B_phi[i], p_f->B_phi_dr[i], p_f->B_phi_dphi[i],
+                p_f->B_phi_dz[i],
+                p_f->B_z[i], p_f->B_z_dr[i], p_f->B_z_dphi[i], p_f->B_z_dz[i]};
             gctransform_pparmuzeta2prpphipz(p_f->mass[i], p_f->charge[i], B_dB,
                                             p_f->phi[i], p_f->ppar[i],
                                             p_f->mu[i], p_f->zeta[i],
@@ -281,13 +286,10 @@ void dist_6D_update_gc(dist_6D_data* dist, particle_simd_gc* p_f,
 
     for(int i = 0; i < NSIMD; i++) {
         if(p_f->running[i] && ok[i]) {
-            unsigned long index = dist_6D_index(i_r[i], i_phi[i], i_z[i],
-                                                i_pr[i], i_pphi[i], i_pz[i],
-                                                i_time[i], i_q[i],
-                                                dist->n_phi, dist->n_z,
-                                                dist->n_pr, dist->n_pphi,
-                                                dist->n_pz, dist->n_time,
-                                                dist->n_q);
+            size_t index = dist_6D_index(
+                i_r[i], i_phi[i], i_z[i], i_pr[i], i_pphi[i], i_pz[i],
+                i_time[i], i_q[i], dist->step_7, dist->step_6, dist->step_5,
+                dist->step_4, dist->step_3, dist->step_2, dist->step_1);
             #pragma omp atomic
             dist->histogram[index] += weight[i];
         }

--- a/src/diag/dist_6D.h
+++ b/src/diag/dist_6D.h
@@ -5,6 +5,7 @@
 #ifndef DIST_6D_H
 #define DIST_6D_H
 
+#include <stdlib.h>
 #include "../ascot5.h"
 #include "../particle.h"
 
@@ -80,6 +81,14 @@ typedef struct {
     int n_q;          /**< number of r bins           */
     real min_q;       /**< value of lowest r bin      */
     real max_q;       /**< value of highest r bin     */
+
+    size_t step_1;    /**< step for 2nd fastest running index   */
+    size_t step_2;    /**< step for 3rd fastest running index   */
+    size_t step_3;    /**< step for 4th fastest running index   */
+    size_t step_4;    /**< step for 5th fastest running index   */
+    size_t step_5;    /**< step for 6th fastest running index   */
+    size_t step_6;    /**< step for 7th fastest running index   */
+    size_t step_7;    /**< step for 8th fastest running index   */
 
     real* histogram;  /**< pointer to start of histogram array */
 } dist_6D_data;

--- a/src/diag/dist_com.h
+++ b/src/diag/dist_com.h
@@ -5,6 +5,7 @@
 #ifndef DIST_COM_H
 #define DIST_COM_H
 
+#include <stdlib.h>
 #include "../ascot5.h"
 #include "../particle.h"
 #include "../B_field.h"
@@ -41,6 +42,9 @@ typedef struct {
     int n_Ptor;          /**< number of Ptor bins                   */
     real min_Ptor;       /**< value of lowest Ptor bin              */
     real max_Ptor;       /**< value of highest Ptor bin             */
+
+    size_t step_1;       /**< step for 2nd fastest running index    */
+    size_t step_2;       /**< step for 3rd fastest running index    */
 
     real* histogram;  /**< pointer to start of histogram array */
 } dist_COM_data;

--- a/src/diag/dist_rho5D.h
+++ b/src/diag/dist_rho5D.h
@@ -5,6 +5,7 @@
 #ifndef DIST_RHO5D_H
 #define DIST_RHO5D_H
 
+#include <stdlib.h>
 #include "../ascot5.h"
 #include "../particle.h"
 
@@ -72,6 +73,13 @@ typedef struct {
     int n_q;          /**< number of charge bins                */
     real min_q;       /**< value of lowest charge bin           */
     real max_q;       /**< value of highest charge bin          */
+
+    size_t step_1;    /**< step for 2nd fastest running index   */
+    size_t step_2;    /**< step for 3rd fastest running index   */
+    size_t step_3;    /**< step for 4th fastest running index   */
+    size_t step_4;    /**< step for 5th fastest running index   */
+    size_t step_5;    /**< step for 6th fastest running index   */
+    size_t step_6;    /**< step for 7th fastest running index   */
 
     real* histogram;  /**< pointer to start of histogram array */
 } dist_rho5D_data;

--- a/src/diag/dist_rho6D.h
+++ b/src/diag/dist_rho6D.h
@@ -5,6 +5,7 @@
 #ifndef DIST_RHO6D_H
 #define DIST_RHO6D_H
 
+#include <stdlib.h>
 #include "../ascot5.h"
 #include "../particle.h"
 
@@ -80,6 +81,14 @@ typedef struct {
     int n_q;          /**< number of charge bins         */
     real min_q;       /**< value of lowest charge bin    */
     real max_q;       /**< value of highest charge bin   */
+
+    size_t step_1;    /**< step for 2nd fastest running index   */
+    size_t step_2;    /**< step for 3rd fastest running index   */
+    size_t step_3;    /**< step for 4th fastest running index   */
+    size_t step_4;    /**< step for 5th fastest running index   */
+    size_t step_5;    /**< step for 6th fastest running index   */
+    size_t step_6;    /**< step for 7th fastest running index   */
+    size_t step_7;    /**< step for 8th fastest running index   */
 
     real* histogram;  /**< pointer to start of histogram array */
 } dist_rho6D_data;


### PR DESCRIPTION
All diagnostics now use size_t instead of int whenever arrays are indexed or allocated. I also included these changes to AFSI since it uses the same distributions as the main program.

I didn't change the array dimensions from int to size_t since for those int should be sufficient (and the dimensions are stored as ints in the HDF5 anyway). To avoid zillion (size_t) casts, I introduced new parameters to the distribution structs that define row, column, etc. sizes in size_t's.

@rui-coelho could you checkout branch https://github.com/ascot4fusion/ascot5/tree/hotfix/45-support-for-large-arrays and verify that now you can use large distributions both in bbnbi5 and ascot5_main?