### PR TITLE
Fixes issue #86

### DIFF
--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -474,6 +474,10 @@ void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
                     p.B_z_dr[i]     = B_dB[9];
                     p.B_z_dphi[i]   = B_dB[10];
                     p.B_z_dz[i]     = B_dB[11];
+
+                    real axisrz[2];
+                    B_field_get_axis_rz(axisrz, &sim->B_data, p.phi[i]);
+                    p.theta[i] = atan2(p.z[i]-axisrz[1], p.r[i]-axisrz[0]);
                 }
             }
             particle_copy_fo(&p, i, &pdiag, i);

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -385,6 +385,12 @@ void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
                     shinethrough[i] = 1;
                 }
                 p.rho[i] = rho[0];
+                /* Update theta value */
+                real axisrz[2];
+                if(!err) {
+                    B_field_get_axis_rz(axisrz, &sim->B_data, p.phi[i]);
+                }
+                p.theta[i] = atan2(p.z[i]-axisrz[1], p.r[i]-axisrz[0]);
 
                 if(!err) {
                     err = plasma_eval_densandtemp(
@@ -474,10 +480,6 @@ void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
                     p.B_z_dr[i]     = B_dB[9];
                     p.B_z_dphi[i]   = B_dB[10];
                     p.B_z_dz[i]     = B_dB[11];
-
-                    real axisrz[2];
-                    B_field_get_axis_rz(axisrz, &sim->B_data, p.phi[i]);
-                    p.theta[i] = atan2(p.z[i]-axisrz[1], p.r[i]-axisrz[0]);
                 }
             }
             particle_copy_fo(&p, i, &pdiag, i);


### PR DESCRIPTION
This assigns the theta values just before collecting diagnostics. This needs to be reworked if ever theta data is needed during the bbnbi simulation itself.