### PR TITLE
Hotfix/96 bbnbi5 resulting markers and distribution weights dont match

### DIFF
--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -490,7 +490,7 @@ void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
             /* Normalize weight with time and add hin so that we don't divide
              * with zero when updating distributions */
             pdiag.time[i]   += hin[i];
-            pdiag.weight[i] /= hin[i];//p.mileage[i] + hin[i];
+            pdiag.weight[i] /= hin[i];
         }
 
         /* Update distributions for markers that finished */

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -490,7 +490,7 @@ void bbnbi_simulate(particle_queue *pq, sim_data* sim) {
             /* Normalize weight with time and add hin so that we don't divide
              * with zero when updating distributions */
             pdiag.time[i]   += hin[i];
-            pdiag.weight[i] /= p.mileage[i] + hin[i];
+            pdiag.weight[i] /= hin[i];//p.mileage[i] + hin[i];
         }
 
         /* Update distributions for markers that finished */


### PR DESCRIPTION
BBNBI ionization distribution was wrong, now it's fixed.