### PR TITLE
Feature/110 some features to analyze 2d wall loads

### DIFF
--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -144,27 +144,44 @@ class wall_2D(DataGroup):
 
         return rmin, rmax
 
-    def getwallarea(self):
-        """Return the corresponsing area for revolving each strip of the 2D
+    def area(self, normal=False, data=None):
+        """Calculate the corresponsing area for revolving each strip of the 2D
         wall around the z-axis.
+
+        Parameters
+        ----------
+        normal : bool, optional
+            If True, calculate and return the surface normal vectors as well.
+        data : dict, optional
+            Dictionary with the wall data. If ``None``, the data is read from
+            the file.
 
         Returns
         -------
-        data : array_like, (N-1)
-            Areas of each revolving strip
+        area : array_like, (nelement,)
+            Surface areas of the wall elements.
+        nvec : array_like, (nelement,3)
+            Normal vectors of the wall elements in (R, z, 0)
+
+            Note that the direction of the normal vector is not specified (it
+            can point either inside or outside).
+
         """
-        w = self.read()
+        if data is None:
+            w = self.read()
+        else:
+            w = data
         r = w['r']
         z = w['z']
-        if r[0] != r[-1]:
-            r = np.append(r, r[0])
-            print('r was not closed')
-        if z[0] != z[-1]:
-            z = np.append(z, z[0])
-            print('z was not closed')
+        norm = np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))
+        area = np.pi*(r[1:]+r[:-1])*norm*unyt.m**2
+        if not normal:
+            return area
+        else:
+            n_vec = np.c_[(z[1:]-z[:-1])/norm, -(r[1:]-r[:-1])/norm, norm*0]
+            return area, n_vec.T
 
-        return np.pi*(r[1:]+r[:-1])*np.sqrt(np.square(r[1:]-r[:-1])+\
-                        np.square(z[1:]-z[:-1]))
+
     def getnormedline(self):
         """Return the length of each strip of the 2D wall.
 

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -144,6 +144,46 @@ class wall_2D(DataGroup):
 
         return rmin, rmax
 
+    def getwallarea(self):
+        """Return the corresponsing area for revolving each strip of the 2D
+        wall around the z-axis.
+
+        Returns
+        -------
+        data : array_like, (N-1)
+            Areas of each revolving strip
+        """
+        w = self.read()
+        r = w['r']
+        z = w['z']
+        if r[0] != r[-1]:
+            r = np.append(r, r[0])
+            print('r was not closed')
+        if z[0] != z[-1]:
+            z = np.append(z, z[0])
+            print('z was not closed')
+
+        return np.pi*(r[1:]+r[:-1])*np.sqrt(np.square(r[1:]-r[:-1])+\
+                        np.square(z[1:]-z[:-1]))
+    def getnormedline(self):
+        """Return the length of each strip of the 2D wall.
+
+        Returns
+        -------
+        data : array_like, (N-1)
+            lenghts of each strip
+        """
+        w = self.read()
+        r = w['r']
+        z = w['z']
+        if r[0] != r[-1]:
+            r = np.append(r, r[0])
+            print('r was not closed')
+        if z[0] != z[-1]:
+            z = np.append(z, z[0])
+            print('z was not closed')
+        return np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))
+
     @staticmethod
     def create_dummy():
         """Create dummy data that has correct format and is valid, but can be
@@ -544,7 +584,7 @@ class wall_3D(DataGroup):
         rwall = self.read()
 
         #Movement in metres
-        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2) 
+        t = movement/np.sqrt(direction[0]**2 + direction[1]**2 + direction[2]**2)
 
         rwall['x1x2x3'][component,:] += t*direction[0]
         rwall['y1y2y3'][component,:] += t*direction[1]

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -193,12 +193,6 @@ class wall_2D(DataGroup):
         w = self.read()
         r = w['r']
         z = w['z']
-        if r[0] != r[-1]:
-            r = np.append(r, r[0])
-            print('r was not closed')
-        if z[0] != z[-1]:
-            z = np.append(z, z[0])
-            print('z was not closed')
         return np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))
 
     @staticmethod

--- a/a5py/ascot5io/wall.py
+++ b/a5py/ascot5io/wall.py
@@ -113,8 +113,11 @@ class wall_2D(DataGroup):
             Line segments [[[r1,z1], [r2,z2]], ...] that form the cross section.
         """
         w = self.read()
-        r = np.append(w["r"], w["r"][0])
-        z = np.append(w["z"], w["z"][0])
+        r = w["r"] #np.append(w["r"], w["r"][0])
+        z = w["z"] #np.append(w["z"], w["z"][0])
+        if (r[0] != r[-1]) or (z[0] != z[-1]):
+            r = np.append(r, r[0])
+            z = np.append(z, z[0])
         lines = np.zeros((r.size-1, 2, 2))
         for i in range(r.size-1):
             lines[i, 0, 0] = r[i]
@@ -146,7 +149,8 @@ class wall_2D(DataGroup):
 
     def area(self, normal=False, data=None):
         """Calculate the corresponsing area for revolving each strip of the 2D
-        wall around the z-axis.
+        wall around the z-axis. Note: the normal vector is returned with only
+        R and z components.
 
         Parameters
         ----------
@@ -173,6 +177,9 @@ class wall_2D(DataGroup):
             w = data
         r = w['r']
         z = w['z']
+        if (r[0] != r[-1]) or (z[0] != z[-1]):
+            r = np.append(r, r[0])
+            z = np.append(z, z[0])
         norm = np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))
         area = np.pi*(r[1:]+r[:-1])*norm*unyt.m**2
         if not normal:
@@ -193,7 +200,10 @@ class wall_2D(DataGroup):
         w = self.read()
         r = w['r']
         z = w['z']
-        return np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))
+        if (r[0] != r[-1]) or (z[0] != z[-1]):
+            r = np.append(r, r[0])
+            z = np.append(z, z[0])
+        return np.sqrt(np.square(r[1:]-r[:-1])+np.square(z[1:]-z[:-1]))*unyt.m
 
     @staticmethod
     def create_dummy():

--- a/a5py/routines/plotting.py
+++ b/a5py/routines/plotting.py
@@ -715,7 +715,8 @@ def line2d(x, y, c=None, xlog="linear", ylog="linear", clog="linear",
         lc.set_array(c[i][1:])
         line = axes.add_collection(lc)
     smap = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
-    plt.colorbar(smap, ax=axes, cax=cax)
+    cax = plt.colorbar(smap, ax=axes, cax=cax)
+    cax.ax.set_ylabel(clabel, rotation=90, labelpad=10)
 
 @openfigureifnoaxes(projection="3d")
 def line3d(x, y, z, c=None, xlog="linear", ylog="linear", zlog="linear",

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -1434,7 +1434,7 @@ class RunMixin(DistMixin):
     @a5plt.openfigureifnoaxes(projection=None)
     def plotwall_2D_parametrized(self, axes=None, particle_load=False,
                                  ref_indices=None, colors=None, xlabel=None,
-                                 ylabel=None):
+                                 ylabel=None, ref_cmap='jet'):
         """Plot heat loads as a function of the parametrized wall contour.
 
         Parameters
@@ -1451,6 +1451,8 @@ class RunMixin(DistMixin):
             Label for the x-axis.
         ylabel : str, optional
             Label for the y-axis.
+        ref_cmap : str, optional
+            Name of the colormap for ref_indices.
         """
 
         wetted, area, edepo, pdepo, iangle = self.getwall_loads()
@@ -1473,7 +1475,7 @@ class RunMixin(DistMixin):
             xlabel = 's ['+str(xdif.units)+']'
         if ylabel is None:
             if particle_load:
-                ylabel = 'Heatload ['+str(pdepo.units/area.units)+']'
+                ylabel = 'Particleload ['+str(pdepo.units/area.units)+']'
             else:
                 ylabel = 'Heatload ['+str(edepo.units/area.units)+']'
         axes.set_xlabel(xlabel)
@@ -1507,7 +1509,7 @@ class RunMixin(DistMixin):
             if colors is None:
                 N_ref = len(ref_indices)
                 import matplotlib as mp
-                colors = mp.cm.jet(np.linspace(0,1,N_ref))
+                colors = mp.cm.get_cmap(ref_cmap)(np.linspace(0,1,N_ref))
             else:
                 if colors.shape[0] != len(ref_indices):
                     raise ValueError('ref_indices and colors len do not match')
@@ -1517,14 +1519,14 @@ class RunMixin(DistMixin):
                 xp     = np.append(xp, xmax)
                 yp     = np.append(yp, yp[ind])
                 colors = np.append(colors, colors[ind, :][np.newaxis, :], axis=0)
-                print(colors.shape)
 
             axes.scatter(xp, yp, s=70, c=colors)
 
     @a5plt.openfigureifnoaxes(projection=None)
     def plotwall_2D_contour(self, axes=None, particle_load=False,
                             ref_indices=None, colors=None, clog="linear",
-                            cmap=None, xlabel=None, ylabel=None, clabel=None):
+                            cmap=None, ref_cmap='jet', xlabel=None, ylabel=None,
+                            clabel=None):
         """Plot heat loads as in the 2D wall contour with a colorbar.
 
         Parameters
@@ -1541,6 +1543,8 @@ class RunMixin(DistMixin):
             color-axis scaling.
         cmap : str, optional
             Name of the colormap.
+        ref_cmap : str, optional
+            Name of the colormap for ref_indices.
         xlabel : str, optional
             Label for the x-axis.
         ylabel : str, optional
@@ -1560,7 +1564,11 @@ class RunMixin(DistMixin):
             xlabel = 'R [m]'
         if ylabel is None:
             ylabel = 'z [m]'
-
+        if clabel is None:
+            if particle_load:
+                clabel = 'Particleload ['+str(pdepo.units/area.units)+']'
+            else:
+                clabel = 'Heatload ['+str(edepo.units/area.units)+']'
         bbox = [np.min(lines[:, :, 0]), np.max(lines[:, :, 0]),\
                 np.min(lines[:, :, 1]), np.max(lines[:, :, 1]),\
                 np.min(y),              np.max(y)]
@@ -1584,8 +1592,7 @@ class RunMixin(DistMixin):
 
             if colors is None:
                 N_ref = len(ref_indices)
-                import matplotlib as mp
-                colors = mp.cm.jet(np.linspace(0,1,N_ref))
+                colors = mp.cm.get_cmap(ref_cmap)(np.linspace(0,1,N_ref))
             else:
                 if colors.shape[0] != len(ref_indices):
                     raise ValueError('ref_indices and colors len do not match')

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -469,6 +469,8 @@ class RunMixin(DistMixin):
         of them receive no loads) but only those that are affected and their
         IDs.
 
+        For 2D walls, iangle, angle of incidence is not calculated.
+
         Parameters
         ----------
         weights : bool, optional
@@ -1428,6 +1430,167 @@ class RunMixin(DistMixin):
         """
         _, area, eload, _, _ = self.getwall_loads()
         a5plt.loadvsarea(area, eload/area, axes=axes)
+
+    @a5plt.openfigureifnoaxes(projection=None)
+    def plotwall_2D_parametrized(self, axes=None, particle_load=False,
+                                 ref_indices=None, colors=None, xlabel=None,
+                                 ylabel=None):
+        """Plot heat loads as a function of the parametrized wall contour.
+
+        Parameters
+        ----------
+        axes : :obj:`~matplotlib.axes.Axes`, optional
+            The axes where figure is plotted or otherwise new figure is created.
+        particle_load : bool, optional
+            Plot particle fluxes instead of powerloads.
+        ref_indices : {array_like, int}, optional
+            Plot 2D wall points given by ref_indices.
+        colors : arraylike, optional
+            Colors of all drawn indices. Must be same length as ref_indices.
+        xlabel : str, optional
+            Label for the x-axis.
+        ylabel : str, optional
+            Label for the y-axis.
+        """
+
+        wetted, area, edepo, pdepo, iangle = self.getwall_loads()
+        xdif = self.wall.getnormedline().flatten()
+        x_orig = np.cumsum(xdif)
+        x = x_orig - xdif/2 #initialize loads at half point
+        #x = x.flatten()
+        y = np.zeros(x.shape)
+        if particle_load:
+            y[wetted] = pdepo / area
+        else:
+            y[wetted] = edepo / area
+
+
+        # wrap x and y values
+        x = np.r_[-xdif[-1]/2, x, x_orig[-1]+xdif[0]/2]
+        y = np.r_[y[-1],       y, y[0]]
+
+        if xlabel is None:
+            xlabel = 's ['+str(xdif.units)+']'
+        if ylabel is None:
+            if particle_load:
+                ylabel = 'Heatload ['+str(pdepo.units/area.units)+']'
+            else:
+                ylabel = 'Heatload ['+str(edepo.units/area.units)+']'
+        axes.set_xlabel(xlabel)
+        axes.set_ylabel(ylabel)
+
+        axes.plot(x, y)
+
+        #set axes limits
+        xmax = x_orig[-1] #for limiting axes
+        xmin = 0
+        ymax = np.max(y)
+        ymin = 0
+
+        axes.set_xlim(xmin, xmax)
+        axes.set_ylim(ymin, ymax*1.1) #10% padding before top
+
+
+        if ref_indices is not None:
+
+            x_ori = np.r_[0, x_orig.flatten()]
+            dx    = np.r_[xdif.flatten()/2, xdif.flatten()[-1]/2]
+            dx2   = x[1:]-x[:-1]
+            dy   = y[1:]-y[:-1]
+            y_ori = y[1:]- dy*(dx/dx2)
+
+            xp = x_ori[ref_indices]
+            yp = y_ori[ref_indices]
+
+            x_max = x_ori[-1]
+
+            if colors is None:
+                N_ref = len(ref_indices)
+                import matplotlib as mp
+                colors = mp.cm.jet(np.linspace(0,1,N_ref))
+            else:
+                if colors.shape[0] != len(ref_indices):
+                    raise ValueError('ref_indices and colors len do not match')
+
+            if 0 in ref_indices:
+                ind = ref_indices.index(0)
+                xp     = np.append(xp, xmax)
+                yp     = np.append(yp, yp[ind])
+                colors = np.append(colors, colors[ind, :][np.newaxis, :], axis=0)
+                print(colors.shape)
+
+            axes.scatter(xp, yp, s=70, c=colors)
+
+    @a5plt.openfigureifnoaxes(projection=None)
+    def plotwall_2D_contour(self, axes=None, particle_load=False,
+                            ref_indices=None, colors=None, clog="linear",
+                            cmap=None, xlabel=None, ylabel=None, clabel=None):
+        """Plot heat loads as in the 2D wall contour with a colorbar.
+
+        Parameters
+        ----------
+        axes : :obj:`~matplotlib.axes.Axes`, optional
+            The axes where figure is plotted or otherwise new figure is created.
+        particle_load : bool, optional
+            Plot particle fluxes instead of powerloads.
+        ref_indices : {array_like, int}, optional
+            Plot 2D wall points given by ref_indices.
+        colors : arraylike, optional
+            Colors of all drawn indices. Must be same length as ref_indices.
+        clog : {"linear", "log", "symlog"}, optional
+            color-axis scaling.
+        cmap : str, optional
+            Name of the colormap.
+        xlabel : str, optional
+            Label for the x-axis.
+        ylabel : str, optional
+            Label for the y-axis.
+        clabel : str, optional
+            Label for the color axis.
+        """
+        wetted, area, edepo, pdepo, iangle = self.getwall_loads()
+        lines = self.wall.getwallcontour()
+        y = np.zeros((lines.shape[0], ))
+        if particle_load:
+            y[wetted] = pdepo / area
+        else:
+            y[wetted] = edepo / area
+
+        if xlabel is None:
+            xlabel = 'R [m]'
+        if ylabel is None:
+            ylabel = 'z [m]'
+
+        bbox = [np.min(lines[:, :, 0]), np.max(lines[:, :, 0]),\
+                np.min(lines[:, :, 1]), np.max(lines[:, :, 1]),\
+                np.min(y),              np.max(y)]
+
+        import matplotlib as mp
+        if cmap is None:
+            cmap ='viridis'
+        cols = mp.cm.get_cmap(cmap)((y - bbox[-2])/(bbox[-1] - bbox[-2]))
+        a5plt.line2d(x=lines[:, :, 0], y=lines[:, :, 1], c=cols, clog=clog,\
+                   xlabel=xlabel, ylabel=ylabel, clabel=clabel, bbox=bbox,\
+                   cmap=cmap, axesequal=True, axes=axes)
+
+        if ref_indices is not None:
+
+            w =self.wall.read()
+            x_ori = w['r']
+            y_ori = w['z']
+
+            xp = x_ori[ref_indices]
+            yp = y_ori[ref_indices]
+
+            if colors is None:
+                N_ref = len(ref_indices)
+                import matplotlib as mp
+                colors = mp.cm.jet(np.linspace(0,1,N_ref))
+            else:
+                if colors.shape[0] != len(ref_indices):
+                    raise ValueError('ref_indices and colors len do not match')
+
+            axes.scatter(xp, yp, s=70, c=colors)
 
     @a5plt.openfigureifnoaxes(projection=None)
     def plotwall_torpol(self, qnt='eload', getaxis=None,log=True, clim=None,


### PR DESCRIPTION
Now possible to calculate the heatloads for 2D walls. 

Also implemented some plotting routines. 

Example:
Note: this simulation had only 1 wall hit so nothing cool seen here. 

ref_indices allows for checking which point correspond to parametrized contour in the R-z contour

`ref_indices = [0,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250]
a5.data.active.plotwall_2D_contour(ref_indices=ref_indices)
a5.data.active.plotwall_2D_parametrized(ref_indices=ref_indices)`

![Screenshot from 2024-07-04 14-27-25](https://github.com/ascot4fusion/ascot5/assets/47065584/6b0e6394-40ef-49df-9df5-7a7105ace3b0)
![Screenshot from 2024-07-04 14-28-16](https://github.com/ascot4fusion/ascot5/assets/47065584/a4a10caf-5160-4074-a8cc-17ccc4b4634f)


