### PR TITLE
add darwin and clang 17 support

### DIFF
--- a/a5py/ascotpy/__init__.py
+++ b/a5py/ascotpy/__init__.py
@@ -12,7 +12,7 @@ import a5py.routines.plotting as a5plt
 from a5py.routines.plotting import openfigureifnoaxes, plt
 from a5py.exceptions import AscotInitException
 
-from .libascot    import LibAscot, _LIBASCOT
+from .libascot    import LibAscot, _LIBASCOT, _get_struct_class
 from .libsimulate import LibSimulate
 from .libproviders import LibProviders
 
@@ -87,13 +87,13 @@ class Ascotpy(LibAscot, LibSimulate, LibProviders):
         self._offload_ready     = False
         self._nmrk              = ctypes.c_int32()
         self._diag_occupied     = False
-        self._offload_data      = ascot2py.struct_c__SA_offload_package()
+        self._offload_data      = _get_struct_class("offload_package")()
         self._offload_array     = ctypes.POINTER(ctypes.c_double)()
         self._int_offload_array = ctypes.POINTER(ctypes.c_int   )()
-        self._inistate = ctypes.POINTER(ascot2py.struct_c__SA_particle_state)()
-        self._endstate = ctypes.POINTER(ascot2py.struct_c__SA_particle_state)()
+        self._inistate = ctypes.POINTER(_get_struct_class("particle_state"))()
+        self._endstate = ctypes.POINTER(_get_struct_class("particle_state"))()
 
-        self._sim = ascot2py.struct_c__SA_sim_offload_data()
+        self._sim = _get_struct_class("sim_offload_data")()
         self._bfield_offload_array  = ctypes.POINTER(ctypes.c_double)()
         self._efield_offload_array  = ctypes.POINTER(ctypes.c_double)()
         self._plasma_offload_array  = ctypes.POINTER(ctypes.c_double)()

--- a/a5py/ascotpy/libascot.py
+++ b/a5py/ascotpy/libascot.py
@@ -36,14 +36,35 @@ try:
         return type(base.__name__, (base,),
                     {'from_param': classmethod(from_param)})
 
+    def _get_struct_class(struct_cname: str) -> type[ctypes.Structure]:
+        """Get the ctypes class of a struct by its C name.
+
+        Required because ctypeslib returns different names depending on the
+        version of clang used to compile the C code.
+
+        Parameters
+        ----------
+        struct_cname : str
+            Name of the struct in the C code.
+
+        Returns
+        -------
+        out : ctypes.Structure
+            The ctypes class of the struct.
+        """
+        for name, obj in ascot2py.__dict__.items():
+            if name.startswith("struct_") and struct_cname in name:
+                return obj
+        return ctypes.Structure
+
     PTR_REAL = _ndpointerwithnull(ctypes.c_double, flags="C_CONTIGUOUS")
     PTR_INT  = _ndpointerwithnull(ctypes.c_int,    flags="C_CONTIGUOUS")
-    PTR_SIM  = ctypes.POINTER(ascot2py.struct_c__SA_sim_offload_data)
+    PTR_SIM  = ctypes.POINTER(_get_struct_class("sim_offload_data"))
     PTR_ARR  = ctypes.POINTER(ctypes.c_double)
-    STRUCT_DIST5DOFFLOAD = ascot2py.struct_c__SA_dist_5D_offload_data
-    STRUCT_DIST5D        = ascot2py.struct_c__SA_dist_5D_data
-    STRUCT_AFSITHERMAL   = ascot2py.struct_c__SA_afsi_thermal_data
-    STRUCT_AFSIDATA      = ascot2py.struct_c__SA_afsi_data
+    STRUCT_DIST5DOFFLOAD = _get_struct_class("dist_5D_offload_data")
+    STRUCT_DIST5D        = _get_struct_class("dist_5D_data")
+    STRUCT_AFSITHERMAL   = _get_struct_class("afsi_thermal_data")
+    STRUCT_AFSIDATA      = _get_struct_class("afsi_data")
     AFSI_REACTIONS       = ascot2py.Reaction__enumvalues
     _LIBASCOT = ascot2py._libraries['libascot.so']
 

--- a/a5py/ascotpy/libsimulate.py
+++ b/a5py/ascotpy/libsimulate.py
@@ -16,7 +16,7 @@ from a5py import physlib
 from a5py.routines.virtualrun import VirtualRun, VirtualBBNBIRun
 from a5py.exceptions import *
 
-from .libascot import _LIBASCOT
+from .libascot import _LIBASCOT, _get_struct_class
 if _LIBASCOT:
     from . import ascot2py
 
@@ -341,7 +341,7 @@ class LibSimulate():
                 p.id      = ids[i]
 
         def initmarkers():
-            ps = ctypes.pointer(ascot2py.struct_c__SA_particle_state())
+            ps = ctypes.pointer(_get_struct_class("particle_state")())
             self._nmrk.value = nmrk
             n_proc = ctypes.c_int32(0)
             ascot2py.prepare_markers(
@@ -421,7 +421,7 @@ class LibSimulate():
                 setattr(inistate[j], name, val)
 
         # Initialize diagnostics array and endstate
-        self._endstate = ctypes.pointer(ascot2py.struct_c__SA_particle_state())
+        self._endstate = ctypes.pointer(_get_struct_class("particle_state")())
         ascot2py.diag_init_offload(ctypes.byref(self._sim.diag_offload_data),
                                    ctypes.byref(self._diag_offload_array),
                                    self._nmrk)
@@ -523,7 +523,7 @@ class LibSimulate():
             raise AscotInitException(
                 "Free previous results before running the simulation")
         # Initialize diagnostics array and endstate
-        self._endstate = ctypes.pointer(ascot2py.struct_c__SA_particle_state())
+        self._endstate = ctypes.pointer(_get_struct_class("particle_state")())
         ascot2py.diag_init_offload(ctypes.byref(self._sim.diag_offload_data),
                                    ctypes.byref(self._diag_offload_array),
                                    nprt)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 CC=h5cc
 LFLAGS=
 
+
 ifdef TRAP_FPE
 	DEFINES+=-DTRAP_FPE=$(TRAP_FPE)
 	CFLAGS+= -fsignaling-nans -ftrapping-math
@@ -53,8 +54,24 @@ ifeq ($(DEBUG),1)
 else
 	CFLAGS+=-O2
 endif
-CFLAGS+=-lm -Wall -fopenmp -fPIC -std=c11 -D_XOPEN_SOURCE=700 \
+CFLAGS+=-Wall -fopenmp -fPIC -std=c11 -D_XOPEN_SOURCE=700 \
 	$(DEFINES) $(FLAGS)
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS+=-D_DARWIN_C_SOURCE # for MONOTONIC_CLOCK_RAW
+	H5_INCLUDES=$(shell dirname $(shell which h5cc))/../include
+	CLANG2PY_ARGS=$(CFLAGS) -I$(H5_INCLUDES)
+# For MacOS, we need to add the clang library path to the environment
+# since built-in clang doesn't have openmp support enabled by default
+ascot2py.py: export CLANG_LIBRARY_PATH=$(shell $(CC) --print-resource-dir)/../..
+endif
+ifeq ($(UNAME_S),Linux)
+	ifdef CONDA_PREFIX
+		CLANG2PY_ARGS=-I$(CONDA_PREFIX)/include/ \
+		  -I$(CONDA_PREFIX)/x86_64-conda-linux-gnu/sysroot/usr/include/
+	endif
+endif
 
 # Write CFLAGS and CC to a file to be included into output
 $(shell echo "#define CFLAGS " $(CFLAGS) > compiler_flags.h)
@@ -155,14 +172,19 @@ all: $(BINS)
 libascot: libascot.so
 	true
 
-libascot.so: CFLAGS+=-fPIC -shared
+ifeq ($(UNAME_S),Darwin)
+ifeq ($(CC), $(filter $(CC), h5cc h5pcc))
+# don't share the hdf5 library since it isn't the same as h5py anyway
+# also.. non't need -shared -lm or -fPIC on MacOS.. they are default/redundant
+libascot.so: CFLAGS+=-noshlib
+endif
+else
 
-ifeq ($(CC),h5cc)
+libascot.so: CFLAGS+=-fPIC -shared -lm
+
+ifeq ($(CC), $(filter $(CC), h5cc h5pcc))
 libascot.so: CFLAGS+=-shlib
 endif
-
-ifeq ($(CC),h5pcc)
-libascot.so: CFLAGS+=-shlib
 endif
 
 libascot.so: libascot.o ascot5_main.o libascot_mem.o afsi.o bbnbi5.o $(OBJS)
@@ -241,8 +263,7 @@ ASCOT2PY_HEADERFILES=ascot5.h particle.h mpi_interface.h endcond.h simulate.h  \
 ascot2py.py : libascot.so
 	$(eval CLANGOMP=$(shell clang --print-resource-dir)) \
 	clang2py -l libascot.so -o $@ $(ASCOT2PY_HEADERFILES) \
-		--clang-args="-I$(CLANGOMP)/include/ -I$(CONDA_PREFIX)/include/\
-		  -I$(CONDA_PREFIX)/x86_64-conda-linux-gnu/sysroot/usr/include/"
+		--clang-args="$(CLANG2PY_ARGS) -I$(CLANGOMP)/include/"
 
 clean:
 	@rm -f *.o *.so *.test *.optrpt $(BINS) $(SIMDIR)*.o $(STEPDIR)*.o \


### PR DESCRIPTION
To get code to run through tests and tutorials on MacOS.. made some changes mostly to src/Makefile.  Also had to make a new abstraction since the structure naming convention on MacOS with clang-17 (which is what I used) has different "mangling".  Interestingly, the mangling looks simpler with the newer clang.  In general though, ascot2py.py looks different on MacOS arm due to different "long double" and packing.  So that file should probably not be kept in the repo.. though I didn't remove it.

I also have a version of this commit against the main branch, but I'm assuming develop with eventually be pulled and this saves a later conflict merge resolution and additional fixes.