### PR TITLE
Fix for calculating distribution moments with distributions extending outside LCFS

### DIFF
--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -769,9 +769,17 @@ class RunMixin(DistMixin):
             nrho   = dist.abscissa_edges("rho").size
             ntheta = dist.abscissa_edges("theta").size
             nphi   = dist.abscissa_edges("phi").size
+            
+            rho_edges = dist.abscissa_edges("rho")
+            minrho = float(rho_edges[0].v)  if hasattr(rho_edges[0],  "v") \
+                else float(rho_edges[0])
+            maxrho = float(rho_edges[-1].v) if hasattr(rho_edges[-1], "v") \
+                else float(rho_edges[-1])
+
             volume, area, r, phi, z = self._root._ascot.input_rhovolume(
                 method=volmethod, tol=1e-1, nrho=nrho, ntheta=ntheta, nphi=nphi,
-                return_area=True, return_coords=True)
+                return_area=True, return_coords=True,
+                minrho=minrho, maxrho=maxrho)
             volume[volume == 0] = 1e-8 # To avoid division by zero
             out = DistMoment(
                 dist.abscissa_edges("rho"), dist.abscissa_edges("theta"),


### PR DESCRIPTION
Modified getdist_moments() to use the actual rho range from the distribution in input_rhovolume() so that the volume grid and (R,z) coordinates match the distribution bins. Previously maxrho defaulted to 1.0, which caused a systematic mismatch when the distribution extends beyond the LCFS  (i.e. DIST_MAX_RHO > 1). 
(I guess my hasattr check is not nessesary)