### PR TITLE
Restore default -O2 and let user FLAGS override the optimization level

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -67,13 +67,13 @@ else ifeq ($(RANDOM),LCG)
 	DEFINES+=-DRANDOM_LCG
 endif
 
-CFLAGS+=-Wall -fPIC -std=c11 -D_XOPEN_SOURCE=700 $(DEFINES) $(FLAGS)
-
 ifeq ($(DEBUG),1)
 	CFLAGS+=-g -fsanitize=address,undefined
 else
-	CFLAGS+=-g
+	CFLAGS+=-O2 -g
 endif
+
+CFLAGS+=-Wall -fPIC -std=c11 -D_XOPEN_SOURCE=700 $(DEFINES) $(FLAGS)
 
 ifeq ($(CC), $(filter $(CC), h5cc h5pcc))
 	CFLAGS += -shlib


### PR DESCRIPTION
Fixes #221 

## What

- Restore `-O2` in the non-debug branch (it became plain `-g` in 6301b31; that commit's
  subject suggests the flag change was unintended). `-g` is kept alongside, so builds retain
  debug symbols as they have since July.
- Move the DEBUG/optimization block *above* the line that appends `$(DEFINES) $(FLAGS)`, so
  user-supplied `FLAGS` come last on the command line and can override the default level
  (last `-O` flag wins for gcc/clang/nvc). Previously `FLAGS=-O3` was silently overridden by
  the built-in `-O2`.

## Diff (3 lines moved, 1 changed)

```make
-CFLAGS+=-Wall -fPIC -std=c11 -D_XOPEN_SOURCE=700 $(DEFINES) $(FLAGS)
-
 ifeq ($(DEBUG),1)
 	CFLAGS+=-g -fsanitize=address,undefined
 else
-	CFLAGS+=-g
+	CFLAGS+=-O2 -g
 endif
 
+CFLAGS+=-Wall -fPIC -std=c11 -D_XOPEN_SOURCE=700 $(DEFINES) $(FLAGS)
+
```

## Why it is safe

- No behavior change for `DEBUG=1` builds.
- Default builds go back to `-O2`, the long-standing level before 6301b31, now with symbols.
- The block only appends to `CFLAGS`; moving it does not interact with the GPU/RANDOM
  conditionals above (those are plain appends too), and `compiler_flags.h` is generated
  after all appends either way.
- Users who pass `FLAGS` get exactly what they asked for; users who pass nothing get -O2 -g.

## How found

While benchmarking the GPU build for the ISC26 Student Cluster Competition I measured no
difference between my "-O2" and "-O3" builds and traced it to the flag ordering; on
rebasing to current develop I noticed the default level had disappeared entirely.

If you would rather keep release builds without `-g`, happy to drop it — say the word and I
rebase (history stays linear).