### PR TITLE
Fuse the three B_3DS component spline evaluations (1.24x on a GPU guiding-centre run, bit-identical)

### DIFF
--- a/a5py/ascot5io/__init__.py
+++ b/a5py/ascot5io/__init__.py
@@ -3,7 +3,7 @@
 from .bfield  import B_TC, B_GS, B_2DS, B_3DS, B_3DST, B_STS
 from .efield  import E_TC, E_1DS, E_3D, E_3DS, E_3DST
 from .marker  import Marker, Prt, GC, FL
-from .plasma  import plasma_1D, plasma_1DS, plasma_1Dt
+from .plasma  import plasma_1D, plasma_2D, plasma_1DS, plasma_1Dt
 from .wall    import wall_2D, wall_3D
 from .neutral import N0_1D, N0_3D
 from .boozer  import Boozer
@@ -35,7 +35,7 @@ HDF5TOOBJ = {
     #"E_3D" : E_3D, "E_3DS" : E_3DS, "E_3DST" : E_3DST,
     "prt" : Prt, "gc" : GC, "fl" : FL,
     "wall_2D" : wall_2D, "wall_3D" : wall_3D,
-    "plasma_1D" : plasma_1D, "plasma_1DS" : plasma_1DS,
+    "plasma_1D" : plasma_1D, "plasma_2D" : plasma_2D, "plasma_1DS" : plasma_1DS,
     "plasma_1Dt" : plasma_1Dt,
     "N0_1D" : N0_1D, "N0_3D" : N0_3D,
     "Boozer" : Boozer, "MHD_STAT" : MHD_STAT, "MHD_NONSTAT" : MHD_NONSTAT,

--- a/a5py/ascot5io/__init__.py
+++ b/a5py/ascot5io/__init__.py
@@ -1,7 +1,7 @@
 """Interface for accessing data in ASCOT5 HDF5 files.
 """
 from .bfield  import B_TC, B_GS, B_2DS, B_3DS, B_3DST, B_STS
-from .efield  import E_TC, E_1DS, E_3D, E_3DS, E_3DST
+from .efield  import E_TC, E_1DS, E_2DS, E_3D, E_3DS, E_3DST
 from .marker  import Marker, Prt, GC, FL
 from .plasma  import plasma_1D, plasma_2D, plasma_1DS, plasma_1Dt
 from .wall    import wall_2D, wall_3D
@@ -31,7 +31,7 @@ from a5py.templates.imasinterface import ExportIMAS
 HDF5TOOBJ = {
     "B_TC" : B_TC, "B_GS" : B_GS, "B_2DS" : B_2DS, "B_3DS" : B_3DS,
     "B_3DST" : B_3DST, "B_STS" : B_STS,
-    "E_TC" : E_TC, "E_1DS" : E_1DS,
+    "E_TC" : E_TC, "E_1DS" : E_1DS, "E_2DS" : E_2DS,
     #"E_3D" : E_3D, "E_3DS" : E_3DS, "E_3DST" : E_3DST,
     "prt" : Prt, "gc" : GC, "fl" : FL,
     "wall_2D" : wall_2D, "wall_3D" : wall_3D,

--- a/a5py/ascot5io/dist.py
+++ b/a5py/ascot5io/dist.py
@@ -485,7 +485,8 @@ class DistMoment:
                 ordinates.append(k[10:])
         return ordinates
 
-    def plot(self, ordinate, axes=None, cax=None, logscale=False, label=None):
+    def plot(self, ordinate, axes=None, cax=None, logscale=False, label=None,
+             color=None):
         """Plot radial or (R,z) profile of a distribution moment.
 
         The plotted profile is the average of (theta, phi) or phi depending
@@ -509,7 +510,7 @@ class DistMoment:
             a5plt.mesh1d(self.rho, ordinate,
                          xlabel="Normalized poloidal flux",
                          ylabel=ylabel, axes=axes, logscale=logscale,
-                         label=label)
+                         label=label, color=color)
         else:
             clabel = ordinate
             ordinate = self.ordinate(ordinate, toravg=True)

--- a/a5py/ascot5io/dist.py
+++ b/a5py/ascot5io/dist.py
@@ -197,13 +197,16 @@ class DistData():
 
         if copy: return dist
 
-    def integrate(self, copy=False, **abscissae):
+    def integrate(self, copy=False, keepdim=False, **abscissae):
         """Integrate distribution along the given dimension.
 
         Parameters
         ----------
         copy : bool, optional
             Retain original distribution and return a copy which is integrated.
+        keepdim : bool, optional
+            Instead of integrating and reducing the dimensionality of the distribution,
+            combine all the bins into one bin.
         **abscissae : slice or array_like
             Name of the coordinate and corresponding slice which is integrated.
 
@@ -237,17 +240,23 @@ class DistData():
                 ds = np.diff(dist.abscissa_edges(k)) * idx
 
             dist._distribution, s = np.average(
-                dist.distribution(), axis=dim, weights=ds, returned=True)
+                dist.distribution(), axis=dim, weights=ds, returned=True,
+                keepdims=keepdim)
 
-            # np.average seems to strip units from ds most of the time but not
-            # always...
-            if hasattr(s, "units"):
-                dist._distribution *= s
+            if keepdim:
+                # Sum over a dimension but leave one (1) bin with all the mass
+                attr = "_" + k
+                setattr(dist, attr, getattr(dist, attr)[[0, -1]])
             else:
-                dist._distribution *= s * ds.units
+                # np.average seems to strip units from ds most of the time but not
+                # always...
+                if hasattr(s, "units"):
+                    dist._distribution *= s
+                else:
+                    dist._distribution *= s * ds.units
 
-            dist.abscissae.remove(k)
-            delattr(dist, "_" + k)
+                dist.abscissae.remove(k)
+                delattr(dist, "_" + k)
 
         if copy: return dist
 

--- a/a5py/ascot5io/efield.py
+++ b/a5py/ascot5io/efield.py
@@ -96,6 +96,109 @@ class E_TC(DataGroup):
         """
         return {"exyz":np.array([0,0,0])}
 
+class E_2DS(DataGroup):
+    """Electric field that is calculated from 2D potential.
+    """
+
+    def read(self):
+        """Read data from HDF5 file.
+
+        Returns
+        -------
+        data : dict
+            Data read from HDF5 stored in the same format as is passed to
+            :meth:`write_hdf5`.
+        """
+        fn   = self._root._ascot.file_getpath()
+        path = self._path
+
+        out = {}
+        with h5py.File(fn,"r") as f:
+            for key in f[path]:
+                out[key] = f[path][key][:]
+
+        out["vpot"] = out["vpot"].T
+        return out
+
+    @staticmethod
+    def write_hdf5(fn, rmin, rmax, nr, zmin, zmax, nz, vpot, desc=None):
+        """Write input data to the HDF5 file.
+
+        Parameters
+        ----------
+        fn : str
+            Full path to the HDF5 file.
+        rmin : float
+            Minimum value in R grid [m].
+        rmax : float
+            Maximum value in R grid [m].
+        nr : int
+            Number of R grid points.
+        zmin : float
+            Minimum value in z grid [m].
+        zmax : float
+            Maximum value in z grid [m].
+        nz : int
+            Number of z grid points.
+        vpot : array_like (nr,nz)
+            Electric field potential [V].
+        desc : str, optional
+            Input description.
+
+        Returns
+        -------
+        name : str
+            Name, i.e. "<type>_<qid>", of the new input that was written.
+
+        Raises
+        ------
+        ValueError
+            If inputs were not consistent.
+        """
+        if vpot.shape   != (nr,nz):
+            raise ValueError("vpot has an inconsinstent shape.")
+
+        parent = "efield"
+        group  = "E_2DS"
+        gname  = ""
+
+        vpot = vpot.T
+
+        # Create a group for this input.
+        with h5py.File(fn, "a") as f:
+            g = add_group(f, parent, group, desc=desc)
+            gname = g.name.split("/")[-1]
+
+            g.create_dataset("rmin", (1,),     data=rmin, dtype="f8")
+            g.create_dataset("rmax", (1,),     data=rmax, dtype="f8")
+            g.create_dataset("nr",   (1,),     data=nr,   dtype="i4")
+            g.create_dataset("zmin", (1,),     data=zmin, dtype="f8")
+            g.create_dataset("zmax", (1,),     data=zmax, dtype="f8")
+            g.create_dataset("nz",   (1,),     data=nz,   dtype="i4")
+            g.create_dataset("vpot", (nz, nr), data=vpot, dtype="f8")
+
+        return gname
+
+    @staticmethod
+    def create_dummy():
+        """Create dummy data that has correct format and is valid, but can be
+        non-sensical.
+
+        This method is intended for testing purposes or to provide data whose
+        presence is needed but which is not actually used in simulation.
+
+        This dummy input sets electric field to zero everywhere.
+
+        Returns
+        -------
+        data : dict
+            Input data that can be passed to ``write_hdf5`` method of
+            a corresponding type.
+        """
+        return {"rmin":1, "rmax":10, "nr":3, "zmin":-10, "zmax":10,
+                "nz":3,
+                "vpot":np.zeros((3,3))}
+
 class E_3D(DataGroup):
     """3D electric field that is linearly interpolated.
 

--- a/a5py/ascot5io/plasma.py
+++ b/a5py/ascot5io/plasma.py
@@ -345,15 +345,15 @@ class plasma_2D(DataGroup):
             Ion species mass [amu].
         charge : array_like (nion,1)
             Ion species charge [e].
-        vtor : array_like (nrho,1)
+        vtor : array_like (nr,nz,1)
             Plasma rotation [rad/s].
         edensity : array_like (nrho,1)
             Electron density [m^-3].
-        etemperature : array_like (nrho,1)
+        etemperature : array_like (nr,nz,1)
             Electron temperature [eV].
-        idensity : array_like (nrho,nion)
+        idensity : array_like (nr,nz,nion)
             Ion density [m^-3].
-        itemperature : array_like (nrho,1)
+        itemperature : array_like (nr,nz)
             Ion temperature [ev].
         desc : str, optional
             Input description.

--- a/a5py/ascot5io/plasma.py
+++ b/a5py/ascot5io/plasma.py
@@ -285,6 +285,165 @@ class plasma_1D(DataGroup):
                 "idensity":1e20*np.ones((3,1)),
                 "itemperature":1e20*np.ones((3,1))}
 
+class plasma_2D(DataGroup):
+    """Plasma profiles with (R,z) dependency.
+    """
+
+    def read(self):
+        """Read data from HDF5 file.
+
+        Returns
+        -------
+        data : dict
+            Data read from HDF5 stored in the same format as is passed to
+            :meth:`write_hdf5`.
+        """
+        fn   = self._root._ascot.file_getpath()
+        path = self._path
+
+        out = {}
+        with h5py.File(fn,"r") as f:
+            for key in f[path]:
+                out[key] = f[path][key][:]
+                if key in ["nion", "nrho"]:
+                    out[key] = int(out[key])
+
+        for name in ["vtor", "edensity", "etemperature", "idensity",
+                     "itemperature"]:
+            out[name] = np.transpose(out[name])
+        return out
+
+    @staticmethod
+    def write_hdf5(fn, nr, nz, nion, rmin, rmax, zmin, zmax, anum, znum, mass,
+                   charge, vtor, edensity, etemperature, idensity, itemperature,
+                   desc=None):
+        """Write input data to the HDF5 file.
+
+        Parameters
+        ----------
+        fn : str
+            Path to hdf5 file.
+        nr : int
+            Number of R grid points.
+        nz : int
+            Number of z grid points.
+        nion : int
+            Number of ion species.
+        rmin : float
+            Minimum R grid value.
+        rmax : float
+            Maximum R grid value.
+        zmin : float
+            Minimum z grid value.
+        zmax : float
+            Maximum z grid value.
+        anum : array_like (nion,1)
+            Ion species atomic mass number
+        znum : array_like (nion,1)
+            Ion species charge number.
+        mass : array_like (nion,1)
+            Ion species mass [amu].
+        charge : array_like (nion,1)
+            Ion species charge [e].
+        vtor : array_like (nrho,1)
+            Plasma rotation [rad/s].
+        edensity : array_like (nrho,1)
+            Electron density [m^-3].
+        etemperature : array_like (nrho,1)
+            Electron temperature [eV].
+        idensity : array_like (nrho,nion)
+            Ion density [m^-3].
+        itemperature : array_like (nrho,1)
+            Ion temperature [ev].
+        desc : str, optional
+            Input description.
+
+        Returns
+        -------
+        name : str
+            Name, i.e. "<type>_<qid>", of the new input that was written.
+
+        Raises
+        ------
+        ValueError
+            If inputs were not consistent.
+        """
+        if vtor.shape != (nr,nz):
+            raise ValueError("Invalid size for toroidal rotation.")
+        if etemperature.shape != (nr,nz):
+            raise ValueError("Invalid size for electron temperature.")
+        if itemperature.shape != (nr,nz):
+            raise ValueError("Invalid size for ion temperature.")
+        if edensity.shape != (nr,nz):
+            raise ValueError("Invalid size for electron density.")
+        if idensity.shape != (nr,nz,nion):
+            raise ValueError("Invalid size for ion density.")
+
+        vtor = np.transpose(vtor)
+        etemperature = np.transpose(etemperature)
+        itemperature = np.transpose(itemperature)
+        edensity = np.transpose(edensity)
+        idensity = np.transpose(idensity)
+
+        parent = "plasma"
+        group  = "plasma_2D"
+        gname  = ""
+
+        with h5py.File(fn, "a") as f:
+            g = add_group(f, parent, group, desc=desc)
+            gname = g.name.split("/")[-1]
+
+            g.create_dataset('nion',   (1,1),    data=nion,   dtype='i4')
+            g.create_dataset('nr',     (1,1),    data=nr,     dtype='i4')
+            g.create_dataset('nz',     (1,1),    data=nz,     dtype='i4')
+            g.create_dataset('rmin',   (1,1),    data=rmin,   dtype='f8')
+            g.create_dataset('rmax',   (1,1),    data=rmax,   dtype='f8')
+            g.create_dataset('zmin',   (1,1),    data=zmin,   dtype='f8')
+            g.create_dataset('zmax',   (1,1),    data=zmax,   dtype='f8')
+            g.create_dataset('znum',   (nion,1), data=znum,   dtype='i4')
+            g.create_dataset('anum',   (nion,1), data=anum,   dtype='i4')
+            g.create_dataset('charge', (nion,1), data=charge, dtype='i4')
+            g.create_dataset('mass',   (nion,1), data=mass,   dtype='f8')
+            g.create_dataset('vtor',   (nz,nr),  data=vtor,   dtype='f8')
+
+            g.create_dataset('etemperature', (nz,nr),    data=etemperature,
+                             dtype='f8')
+            g.create_dataset('edensity',     (nz,nr),    data=edensity,
+                             dtype='f8')
+            g.create_dataset('itemperature', (nz,nr),    data=itemperature,
+                             dtype='f8')
+            g.create_dataset('idensity',     (nion,nz,nr), data=idensity,
+                             dtype='f8')
+
+        return gname
+
+    @staticmethod
+    def create_dummy():
+        """Create dummy data that has correct format and is valid, but can be
+        non-sensical.
+
+        This method is intended for testing purposes or to provide data whose
+        presence is needed but which is not actually used in simulation.
+
+        The dummy output is an uniform hydrogen plasma.
+
+        Returns
+        -------
+        data : dict
+            Input data that can be passed to ``write_hdf5`` method of
+            a corresponding type.
+        """
+        nr, nz = 3, 4
+        return {
+            "nr":nr, "nz":nz, "nion":1, "rmin":0, "rmax":1, "zmin":-1, "zmax":1,
+            "znum":np.array([1]), "anum":np.array([1]),
+            "mass":np.array([1]), "charge":np.array([1]),
+            "vtor":np.zeros((nr,nz)),
+            "edensity":np.full((nr,nz), 1e20),
+            "etemperature":np.full((nr,nz), 1e3),
+            "idensity":np.full((nr,nz,1), 1e20),
+            "itemperature":np.full((nr,nz), 1e3)}
+
 class plasma_1DS(DataGroup):
     """Same input as :class:`plasma_1D` but interpolated with splines.
 

--- a/a5py/ascotpy/ascot2py.py
+++ b/a5py/ascotpy/ascot2py.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# TARGET arch is: ['-I/usr/share/miniconda/envs/ascot-dev/include/', '-I/usr/share/miniconda/envs/ascot-dev/x86_64-conda-linux-gnu/sysroot/usr/include/', '-I/usr/share/miniconda/envs/ascot-dev/lib/clang/15.0.7/include/']
+# TARGET arch is: ['-I/home/sarkimk1/miniconda3/envs/clang/include/', '-I/home/sarkimk1/miniconda3/envs/clang/x86_64-conda-linux-gnu/sysroot/usr/include/', '-I/home/sarkimk1/miniconda3/envs/clang/lib/clang/14.0.6/include/']
 # WORD_SIZE is: 8
 # POINTER_SIZE is: 8
 # LONGDOUBLE_SIZE is: 16
@@ -27,11 +27,11 @@ class AsDictMixin:
             type_ = type(value)
             if hasattr(value, "_length_") and hasattr(value, "_type_"):
                 # array
-                type_ = type_._type_
-                if hasattr(type_, 'as_dict'):
-                    value = [type_.as_dict(v) for v in value]
+                if not hasattr(type_, "as_dict"):
+                    value = [v for v in value]
                 else:
-                    value = [i for i in value]
+                    type_ = type_._type_
+                    value = [type_.as_dict(v) for v in value]
             elif hasattr(value, "contents") and hasattr(value, "_type_"):
                 # pointer
                 try:
@@ -167,11 +167,11 @@ def char_pointer_cast(string, encoding='utf-8'):
 
 integer = ctypes.c_int64
 real = ctypes.c_double
-class struct_B_GS_data(Structure):
+class struct_c__SA_B_GS_data(Structure):
     pass
 
-struct_B_GS_data._pack_ = 1 # source:False
-struct_B_GS_data._fields_ = [
+struct_c__SA_B_GS_data._pack_ = 1 # source:False
+struct_c__SA_B_GS_data._fields_ = [
     ('R0', ctypes.c_double),
     ('z0', ctypes.c_double),
     ('raxis', ctypes.c_double),
@@ -188,70 +188,43 @@ struct_B_GS_data._fields_ = [
     ('delta0', ctypes.c_double),
 ]
 
-B_GS_data = struct_B_GS_data
-try:
-    B_GS_init = _libraries['libascot.so'].B_GS_init
-    B_GS_init.restype = ctypes.c_int32
-    B_GS_init.argtypes = [ctypes.POINTER(struct_B_GS_data), real, real, real, real, real, real, real, real, ctypes.c_double * 14, ctypes.c_int32, real, real, real]
-except AttributeError:
-    pass
-try:
-    B_GS_free = _libraries['libascot.so'].B_GS_free
-    B_GS_free.restype = None
-    B_GS_free.argtypes = [ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_offload = _libraries['libascot.so'].B_GS_offload
-    B_GS_offload.restype = None
-    B_GS_offload.argtypes = [ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
+B_GS_data = struct_c__SA_B_GS_data
+B_GS_init = _libraries['libascot.so'].B_GS_init
+B_GS_init.restype = ctypes.c_int32
+B_GS_init.argtypes = [ctypes.POINTER(struct_c__SA_B_GS_data), real, real, real, real, real, real, real, real, ctypes.c_double * 14, ctypes.c_int32, real, real, real]
+B_GS_free = _libraries['libascot.so'].B_GS_free
+B_GS_free.restype = None
+B_GS_free.argtypes = [ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_offload = _libraries['libascot.so'].B_GS_offload
+B_GS_offload.restype = None
+B_GS_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_GS_data)]
 a5err = ctypes.c_uint64
-try:
-    B_GS_eval_B = _libraries['libascot.so'].B_GS_eval_B
-    B_GS_eval_B.restype = a5err
-    B_GS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_eval_psi = _libraries['libascot.so'].B_GS_eval_psi
-    B_GS_eval_psi.restype = a5err
-    B_GS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_eval_psi_dpsi = _libraries['libascot.so'].B_GS_eval_psi_dpsi
-    B_GS_eval_psi_dpsi.restype = a5err
-    B_GS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_eval_rho_drho = _libraries['libascot.so'].B_GS_eval_rho_drho
-    B_GS_eval_rho_drho.restype = a5err
-    B_GS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_eval_B_dB = _libraries['libascot.so'].B_GS_eval_B_dB
-    B_GS_eval_B_dB.restype = a5err
-    B_GS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-try:
-    B_GS_get_axis_rz = _libraries['libascot.so'].B_GS_get_axis_rz
-    B_GS_get_axis_rz.restype = a5err
-    B_GS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_GS_data)]
-except AttributeError:
-    pass
-class struct_B_2DS_data(Structure):
+B_GS_eval_B = _libraries['libascot.so'].B_GS_eval_B
+B_GS_eval_B.restype = a5err
+B_GS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_eval_psi = _libraries['libascot.so'].B_GS_eval_psi
+B_GS_eval_psi.restype = a5err
+B_GS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_eval_psi_dpsi = _libraries['libascot.so'].B_GS_eval_psi_dpsi
+B_GS_eval_psi_dpsi.restype = a5err
+B_GS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_eval_rho_drho = _libraries['libascot.so'].B_GS_eval_rho_drho
+B_GS_eval_rho_drho.restype = a5err
+B_GS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_eval_B_dB = _libraries['libascot.so'].B_GS_eval_B_dB
+B_GS_eval_B_dB.restype = a5err
+B_GS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_c__SA_B_GS_data)]
+B_GS_get_axis_rz = _libraries['libascot.so'].B_GS_get_axis_rz
+B_GS_get_axis_rz.restype = a5err
+B_GS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_GS_data)]
+class struct_c__SA_B_2DS_data(Structure):
     pass
 
-class struct_interp2D_data(Structure):
+class struct_c__SA_interp2D_data(Structure):
     pass
 
-struct_interp2D_data._pack_ = 1 # source:False
-struct_interp2D_data._fields_ = [
+struct_c__SA_interp2D_data._pack_ = 1 # source:False
+struct_c__SA_interp2D_data._fields_ = [
     ('n_x', ctypes.c_int32),
     ('n_y', ctypes.c_int32),
     ('bc_x', ctypes.c_int32),
@@ -265,81 +238,54 @@ struct_interp2D_data._fields_ = [
     ('c', ctypes.POINTER(ctypes.c_double)),
 ]
 
-struct_B_2DS_data._pack_ = 1 # source:False
-struct_B_2DS_data._fields_ = [
+struct_c__SA_B_2DS_data._pack_ = 1 # source:False
+struct_c__SA_B_2DS_data._fields_ = [
     ('psi0', ctypes.c_double),
     ('psi1', ctypes.c_double),
     ('axis_r', ctypes.c_double),
     ('axis_z', ctypes.c_double),
-    ('psi', struct_interp2D_data),
-    ('B_r', struct_interp2D_data),
-    ('B_phi', struct_interp2D_data),
-    ('B_z', struct_interp2D_data),
+    ('psi', struct_c__SA_interp2D_data),
+    ('B_r', struct_c__SA_interp2D_data),
+    ('B_phi', struct_c__SA_interp2D_data),
+    ('B_z', struct_c__SA_interp2D_data),
 ]
 
-B_2DS_data = struct_B_2DS_data
-try:
-    B_2DS_init = _libraries['libascot.so'].B_2DS_init
-    B_2DS_init.restype = ctypes.c_int32
-    B_2DS_init.argtypes = [ctypes.POINTER(struct_B_2DS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, real, real, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    B_2DS_free = _libraries['libascot.so'].B_2DS_free
-    B_2DS_free.restype = None
-    B_2DS_free.argtypes = [ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_offload = _libraries['libascot.so'].B_2DS_offload
-    B_2DS_offload.restype = None
-    B_2DS_offload.argtypes = [ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_eval_psi = _libraries['libascot.so'].B_2DS_eval_psi
-    B_2DS_eval_psi.restype = a5err
-    B_2DS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_eval_psi_dpsi = _libraries['libascot.so'].B_2DS_eval_psi_dpsi
-    B_2DS_eval_psi_dpsi.restype = a5err
-    B_2DS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_eval_rho_drho = _libraries['libascot.so'].B_2DS_eval_rho_drho
-    B_2DS_eval_rho_drho.restype = a5err
-    B_2DS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_eval_B = _libraries['libascot.so'].B_2DS_eval_B
-    B_2DS_eval_B.restype = a5err
-    B_2DS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_eval_B_dB = _libraries['libascot.so'].B_2DS_eval_B_dB
-    B_2DS_eval_B_dB.restype = a5err
-    B_2DS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-try:
-    B_2DS_get_axis_rz = _libraries['libascot.so'].B_2DS_get_axis_rz
-    B_2DS_get_axis_rz.restype = a5err
-    B_2DS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_2DS_data)]
-except AttributeError:
-    pass
-class struct_B_3DS_data(Structure):
+B_2DS_data = struct_c__SA_B_2DS_data
+B_2DS_init = _libraries['libascot.so'].B_2DS_init
+B_2DS_init.restype = ctypes.c_int32
+B_2DS_init.argtypes = [ctypes.POINTER(struct_c__SA_B_2DS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, real, real, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+B_2DS_free = _libraries['libascot.so'].B_2DS_free
+B_2DS_free.restype = None
+B_2DS_free.argtypes = [ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_offload = _libraries['libascot.so'].B_2DS_offload
+B_2DS_offload.restype = None
+B_2DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_eval_psi = _libraries['libascot.so'].B_2DS_eval_psi
+B_2DS_eval_psi.restype = a5err
+B_2DS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_eval_psi_dpsi = _libraries['libascot.so'].B_2DS_eval_psi_dpsi
+B_2DS_eval_psi_dpsi.restype = a5err
+B_2DS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_eval_rho_drho = _libraries['libascot.so'].B_2DS_eval_rho_drho
+B_2DS_eval_rho_drho.restype = a5err
+B_2DS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_eval_B = _libraries['libascot.so'].B_2DS_eval_B
+B_2DS_eval_B.restype = a5err
+B_2DS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_eval_B_dB = _libraries['libascot.so'].B_2DS_eval_B_dB
+B_2DS_eval_B_dB.restype = a5err
+B_2DS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+B_2DS_get_axis_rz = _libraries['libascot.so'].B_2DS_get_axis_rz
+B_2DS_get_axis_rz.restype = a5err
+B_2DS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_2DS_data)]
+class struct_c__SA_B_3DS_data(Structure):
     pass
 
-class struct_interp3D_data(Structure):
+class struct_c__SA_interp3D_data(Structure):
     pass
 
-struct_interp3D_data._pack_ = 1 # source:False
-struct_interp3D_data._fields_ = [
+struct_c__SA_interp3D_data._pack_ = 1 # source:False
+struct_c__SA_interp3D_data._fields_ = [
     ('n_x', ctypes.c_int32),
     ('n_y', ctypes.c_int32),
     ('n_z', ctypes.c_int32),
@@ -358,81 +304,54 @@ struct_interp3D_data._fields_ = [
     ('c', ctypes.POINTER(ctypes.c_double)),
 ]
 
-struct_B_3DS_data._pack_ = 1 # source:False
-struct_B_3DS_data._fields_ = [
+struct_c__SA_B_3DS_data._pack_ = 1 # source:False
+struct_c__SA_B_3DS_data._fields_ = [
     ('psi0', ctypes.c_double),
     ('psi1', ctypes.c_double),
     ('axis_r', ctypes.c_double),
     ('axis_z', ctypes.c_double),
-    ('psi', struct_interp2D_data),
-    ('B_r', struct_interp3D_data),
-    ('B_phi', struct_interp3D_data),
-    ('B_z', struct_interp3D_data),
+    ('psi', struct_c__SA_interp2D_data),
+    ('B_r', struct_c__SA_interp3D_data),
+    ('B_phi', struct_c__SA_interp3D_data),
+    ('B_z', struct_c__SA_interp3D_data),
 ]
 
-B_3DS_data = struct_B_3DS_data
-try:
-    B_3DS_init = _libraries['libascot.so'].B_3DS_init
-    B_3DS_init.restype = ctypes.c_int32
-    B_3DS_init.argtypes = [ctypes.POINTER(struct_B_3DS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, real, real, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    B_3DS_free = _libraries['libascot.so'].B_3DS_free
-    B_3DS_free.restype = None
-    B_3DS_free.argtypes = [ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_offload = _libraries['libascot.so'].B_3DS_offload
-    B_3DS_offload.restype = None
-    B_3DS_offload.argtypes = [ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_eval_psi = _libraries['libascot.so'].B_3DS_eval_psi
-    B_3DS_eval_psi.restype = a5err
-    B_3DS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_eval_psi_dpsi = _libraries['libascot.so'].B_3DS_eval_psi_dpsi
-    B_3DS_eval_psi_dpsi.restype = a5err
-    B_3DS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_eval_rho_drho = _libraries['libascot.so'].B_3DS_eval_rho_drho
-    B_3DS_eval_rho_drho.restype = a5err
-    B_3DS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_eval_B = _libraries['libascot.so'].B_3DS_eval_B
-    B_3DS_eval_B.restype = a5err
-    B_3DS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_eval_B_dB = _libraries['libascot.so'].B_3DS_eval_B_dB
-    B_3DS_eval_B_dB.restype = a5err
-    B_3DS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-try:
-    B_3DS_get_axis_rz = _libraries['libascot.so'].B_3DS_get_axis_rz
-    B_3DS_get_axis_rz.restype = a5err
-    B_3DS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_3DS_data)]
-except AttributeError:
-    pass
-class struct_B_STS_data(Structure):
+B_3DS_data = struct_c__SA_B_3DS_data
+B_3DS_init = _libraries['libascot.so'].B_3DS_init
+B_3DS_init.restype = ctypes.c_int32
+B_3DS_init.argtypes = [ctypes.POINTER(struct_c__SA_B_3DS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, real, real, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+B_3DS_free = _libraries['libascot.so'].B_3DS_free
+B_3DS_free.restype = None
+B_3DS_free.argtypes = [ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_offload = _libraries['libascot.so'].B_3DS_offload
+B_3DS_offload.restype = None
+B_3DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_eval_psi = _libraries['libascot.so'].B_3DS_eval_psi
+B_3DS_eval_psi.restype = a5err
+B_3DS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_eval_psi_dpsi = _libraries['libascot.so'].B_3DS_eval_psi_dpsi
+B_3DS_eval_psi_dpsi.restype = a5err
+B_3DS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_eval_rho_drho = _libraries['libascot.so'].B_3DS_eval_rho_drho
+B_3DS_eval_rho_drho.restype = a5err
+B_3DS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_eval_B = _libraries['libascot.so'].B_3DS_eval_B
+B_3DS_eval_B.restype = a5err
+B_3DS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_eval_B_dB = _libraries['libascot.so'].B_3DS_eval_B_dB
+B_3DS_eval_B_dB.restype = a5err
+B_3DS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+B_3DS_get_axis_rz = _libraries['libascot.so'].B_3DS_get_axis_rz
+B_3DS_get_axis_rz.restype = a5err
+B_3DS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_3DS_data)]
+class struct_c__SA_B_STS_data(Structure):
     pass
 
-class struct_linint1D_data(Structure):
+class struct_c__SA_linint1D_data(Structure):
     pass
 
-struct_linint1D_data._pack_ = 1 # source:False
-struct_linint1D_data._fields_ = [
+struct_c__SA_linint1D_data._pack_ = 1 # source:False
+struct_c__SA_linint1D_data._fields_ = [
     ('n_x', ctypes.c_int32),
     ('bc_x', ctypes.c_int32),
     ('x_min', ctypes.c_double),
@@ -441,78 +360,51 @@ struct_linint1D_data._fields_ = [
     ('c', ctypes.POINTER(ctypes.c_double)),
 ]
 
-struct_B_STS_data._pack_ = 1 # source:False
-struct_B_STS_data._fields_ = [
+struct_c__SA_B_STS_data._pack_ = 1 # source:False
+struct_c__SA_B_STS_data._fields_ = [
     ('psi0', ctypes.c_double),
     ('psi1', ctypes.c_double),
-    ('axis_r', struct_linint1D_data),
-    ('axis_z', struct_linint1D_data),
-    ('psi', struct_interp3D_data),
-    ('B_r', struct_interp3D_data),
-    ('B_phi', struct_interp3D_data),
-    ('B_z', struct_interp3D_data),
+    ('axis_r', struct_c__SA_linint1D_data),
+    ('axis_z', struct_c__SA_linint1D_data),
+    ('psi', struct_c__SA_interp3D_data),
+    ('B_r', struct_c__SA_interp3D_data),
+    ('B_phi', struct_c__SA_interp3D_data),
+    ('B_z', struct_c__SA_interp3D_data),
 ]
 
-B_STS_data = struct_B_STS_data
-try:
-    B_STS_init = _libraries['libascot.so'].B_STS_init
-    B_STS_init.restype = ctypes.c_int32
-    B_STS_init.argtypes = [ctypes.POINTER(struct_B_STS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    B_STS_free = _libraries['libascot.so'].B_STS_free
-    B_STS_free.restype = None
-    B_STS_free.argtypes = [ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_offload = _libraries['libascot.so'].B_STS_offload
-    B_STS_offload.restype = None
-    B_STS_offload.argtypes = [ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_eval_psi = _libraries['libascot.so'].B_STS_eval_psi
-    B_STS_eval_psi.restype = a5err
-    B_STS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_eval_psi_dpsi = _libraries['libascot.so'].B_STS_eval_psi_dpsi
-    B_STS_eval_psi_dpsi.restype = a5err
-    B_STS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_eval_rho_drho = _libraries['libascot.so'].B_STS_eval_rho_drho
-    B_STS_eval_rho_drho.restype = a5err
-    B_STS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_eval_B = _libraries['libascot.so'].B_STS_eval_B
-    B_STS_eval_B.restype = a5err
-    B_STS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_eval_B_dB = _libraries['libascot.so'].B_STS_eval_B_dB
-    B_STS_eval_B_dB.restype = a5err
-    B_STS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_B_STS_data)]
-except AttributeError:
-    pass
-try:
-    B_STS_get_axis_rz = _libraries['libascot.so'].B_STS_get_axis_rz
-    B_STS_get_axis_rz.restype = a5err
-    B_STS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_STS_data), real]
-except AttributeError:
-    pass
-class struct_B_TC_data(Structure):
+B_STS_data = struct_c__SA_B_STS_data
+B_STS_init = _libraries['libascot.so'].B_STS_init
+B_STS_init.restype = ctypes.c_int32
+B_STS_init.argtypes = [ctypes.POINTER(struct_c__SA_B_STS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+B_STS_free = _libraries['libascot.so'].B_STS_free
+B_STS_free.restype = None
+B_STS_free.argtypes = [ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_offload = _libraries['libascot.so'].B_STS_offload
+B_STS_offload.restype = None
+B_STS_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_eval_psi = _libraries['libascot.so'].B_STS_eval_psi
+B_STS_eval_psi.restype = a5err
+B_STS_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_eval_psi_dpsi = _libraries['libascot.so'].B_STS_eval_psi_dpsi
+B_STS_eval_psi_dpsi.restype = a5err
+B_STS_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_eval_rho_drho = _libraries['libascot.so'].B_STS_eval_rho_drho
+B_STS_eval_rho_drho.restype = a5err
+B_STS_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_eval_B = _libraries['libascot.so'].B_STS_eval_B
+B_STS_eval_B.restype = a5err
+B_STS_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_eval_B_dB = _libraries['libascot.so'].B_STS_eval_B_dB
+B_STS_eval_B_dB.restype = a5err
+B_STS_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_c__SA_B_STS_data)]
+B_STS_get_axis_rz = _libraries['libascot.so'].B_STS_get_axis_rz
+B_STS_get_axis_rz.restype = a5err
+B_STS_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_STS_data), real]
+class struct_c__SA_B_TC_data(Structure):
     pass
 
-struct_B_TC_data._pack_ = 1 # source:False
-struct_B_TC_data._fields_ = [
+struct_c__SA_B_TC_data._pack_ = 1 # source:False
+struct_c__SA_B_TC_data._fields_ = [
     ('axisr', ctypes.c_double),
     ('axisz', ctypes.c_double),
     ('psival', ctypes.c_double),
@@ -521,61 +413,34 @@ struct_B_TC_data._fields_ = [
     ('dB', ctypes.c_double * 9),
 ]
 
-B_TC_data = struct_B_TC_data
-try:
-    B_TC_init = _libraries['libascot.so'].B_TC_init
-    B_TC_init.restype = ctypes.c_int32
-    B_TC_init.argtypes = [ctypes.POINTER(struct_B_TC_data), real, real, real, real, ctypes.c_double * 3, ctypes.c_double * 9]
-except AttributeError:
-    pass
-try:
-    B_TC_free = _libraries['libascot.so'].B_TC_free
-    B_TC_free.restype = None
-    B_TC_free.argtypes = [ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_offload = _libraries['libascot.so'].B_TC_offload
-    B_TC_offload.restype = None
-    B_TC_offload.argtypes = [ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_eval_B = _libraries['libascot.so'].B_TC_eval_B
-    B_TC_eval_B.restype = a5err
-    B_TC_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_eval_psi = _libraries['libascot.so'].B_TC_eval_psi
-    B_TC_eval_psi.restype = a5err
-    B_TC_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_eval_psi_dpsi = _libraries['libascot.so'].B_TC_eval_psi_dpsi
-    B_TC_eval_psi_dpsi.restype = a5err
-    B_TC_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_eval_rho_drho = _libraries['libascot.so'].B_TC_eval_rho_drho
-    B_TC_eval_rho_drho.restype = a5err
-    B_TC_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_eval_B_dB = _libraries['libascot.so'].B_TC_eval_B_dB
-    B_TC_eval_B_dB.restype = a5err
-    B_TC_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
-try:
-    B_TC_get_axis_rz = _libraries['libascot.so'].B_TC_get_axis_rz
-    B_TC_get_axis_rz.restype = a5err
-    B_TC_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_TC_data)]
-except AttributeError:
-    pass
+B_TC_data = struct_c__SA_B_TC_data
+B_TC_init = _libraries['libascot.so'].B_TC_init
+B_TC_init.restype = ctypes.c_int32
+B_TC_init.argtypes = [ctypes.POINTER(struct_c__SA_B_TC_data), real, real, real, real, ctypes.c_double * 3, ctypes.c_double * 9]
+B_TC_free = _libraries['libascot.so'].B_TC_free
+B_TC_free.restype = None
+B_TC_free.argtypes = [ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_offload = _libraries['libascot.so'].B_TC_offload
+B_TC_offload.restype = None
+B_TC_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_eval_B = _libraries['libascot.so'].B_TC_eval_B
+B_TC_eval_B.restype = a5err
+B_TC_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_eval_psi = _libraries['libascot.so'].B_TC_eval_psi
+B_TC_eval_psi.restype = a5err
+B_TC_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_eval_psi_dpsi = _libraries['libascot.so'].B_TC_eval_psi_dpsi
+B_TC_eval_psi_dpsi.restype = a5err
+B_TC_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_eval_rho_drho = _libraries['libascot.so'].B_TC_eval_rho_drho
+B_TC_eval_rho_drho.restype = a5err
+B_TC_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_eval_B_dB = _libraries['libascot.so'].B_TC_eval_B_dB
+B_TC_eval_B_dB.restype = a5err
+B_TC_eval_B_dB.argtypes = [ctypes.c_double * 12, real, real, real, ctypes.POINTER(struct_c__SA_B_TC_data)]
+B_TC_get_axis_rz = _libraries['libascot.so'].B_TC_get_axis_rz
+B_TC_get_axis_rz.restype = a5err
+B_TC_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_TC_data)]
 
 # values for enumeration 'B_field_type'
 B_field_type__enumvalues = {
@@ -591,11 +456,11 @@ B_field_type_3DS = 2
 B_field_type_STS = 3
 B_field_type_TC = 4
 B_field_type = ctypes.c_uint32 # enum
-class struct_B_field_data(Structure):
+class struct_c__SA_B_field_data(Structure):
     pass
 
-struct_B_field_data._pack_ = 1 # source:False
-struct_B_field_data._fields_ = [
+struct_c__SA_B_field_data._pack_ = 1 # source:False
+struct_c__SA_B_field_data._fields_ = [
     ('type', B_field_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('BGS', B_GS_data),
@@ -605,102 +470,63 @@ struct_B_field_data._fields_ = [
     ('BTC', B_TC_data),
 ]
 
-B_field_data = struct_B_field_data
-try:
-    B_field_free = _libraries['libascot.so'].B_field_free
-    B_field_free.restype = None
-    B_field_free.argtypes = [ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_offload = _libraries['libascot.so'].B_field_offload
-    B_field_offload.restype = None
-    B_field_offload.argtypes = [ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_psi = _libraries['libascot.so'].B_field_eval_psi
-    B_field_eval_psi.restype = a5err
-    B_field_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_psi_dpsi = _libraries['libascot.so'].B_field_eval_psi_dpsi
-    B_field_eval_psi_dpsi.restype = a5err
-    B_field_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_rho = _libraries['libascot.so'].B_field_eval_rho
-    B_field_eval_rho.restype = a5err
-    B_field_eval_rho.argtypes = [ctypes.c_double * 2, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_rho_drho = _libraries['libascot.so'].B_field_eval_rho_drho
-    B_field_eval_rho_drho.restype = a5err
-    B_field_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_B = _libraries['libascot.so'].B_field_eval_B
-    B_field_eval_B.restype = a5err
-    B_field_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_eval_B_dB = _libraries['libascot.so'].B_field_eval_B_dB
-    B_field_eval_B_dB.restype = a5err
-    B_field_eval_B_dB.argtypes = [ctypes.c_double * 15, real, real, real, real, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    B_field_get_axis_rz = _libraries['libascot.so'].B_field_get_axis_rz
-    B_field_get_axis_rz.restype = a5err
-    B_field_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_B_field_data), real]
-except AttributeError:
-    pass
-class struct_E_TC_data(Structure):
+B_field_data = struct_c__SA_B_field_data
+B_field_free = _libraries['libascot.so'].B_field_free
+B_field_free.restype = None
+B_field_free.argtypes = [ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_offload = _libraries['libascot.so'].B_field_offload
+B_field_offload.restype = None
+B_field_offload.argtypes = [ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_psi = _libraries['libascot.so'].B_field_eval_psi
+B_field_eval_psi.restype = a5err
+B_field_eval_psi.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_psi_dpsi = _libraries['libascot.so'].B_field_eval_psi_dpsi
+B_field_eval_psi_dpsi.restype = a5err
+B_field_eval_psi_dpsi.argtypes = [ctypes.c_double * 4, real, real, real, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_rho = _libraries['libascot.so'].B_field_eval_rho
+B_field_eval_rho.restype = a5err
+B_field_eval_rho.argtypes = [ctypes.c_double * 2, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_rho_drho = _libraries['libascot.so'].B_field_eval_rho_drho
+B_field_eval_rho_drho.restype = a5err
+B_field_eval_rho_drho.argtypes = [ctypes.c_double * 4, real, real, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_B = _libraries['libascot.so'].B_field_eval_B
+B_field_eval_B.restype = a5err
+B_field_eval_B.argtypes = [ctypes.c_double * 3, real, real, real, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_eval_B_dB = _libraries['libascot.so'].B_field_eval_B_dB
+B_field_eval_B_dB.restype = a5err
+B_field_eval_B_dB.argtypes = [ctypes.c_double * 15, real, real, real, real, ctypes.POINTER(struct_c__SA_B_field_data)]
+B_field_get_axis_rz = _libraries['libascot.so'].B_field_get_axis_rz
+B_field_get_axis_rz.restype = a5err
+B_field_get_axis_rz.argtypes = [ctypes.c_double * 2, ctypes.POINTER(struct_c__SA_B_field_data), real]
+class struct_c__SA_E_TC_data(Structure):
     pass
 
-struct_E_TC_data._pack_ = 1 # source:False
-struct_E_TC_data._fields_ = [
+struct_c__SA_E_TC_data._pack_ = 1 # source:False
+struct_c__SA_E_TC_data._fields_ = [
     ('Exyz', ctypes.c_double * 3),
 ]
 
-E_TC_data = struct_E_TC_data
-try:
-    E_TC_init = _libraries['libascot.so'].E_TC_init
-    E_TC_init.restype = ctypes.c_int32
-    E_TC_init.argtypes = [ctypes.POINTER(struct_E_TC_data), ctypes.c_double * 3]
-except AttributeError:
-    pass
-try:
-    E_TC_free = _libraries['libascot.so'].E_TC_free
-    E_TC_free.restype = None
-    E_TC_free.argtypes = [ctypes.POINTER(struct_E_TC_data)]
-except AttributeError:
-    pass
-try:
-    E_TC_offload = _libraries['libascot.so'].E_TC_offload
-    E_TC_offload.restype = None
-    E_TC_offload.argtypes = [ctypes.POINTER(struct_E_TC_data)]
-except AttributeError:
-    pass
-try:
-    E_TC_eval_E = _libraries['libascot.so'].E_TC_eval_E
-    E_TC_eval_E.restype = a5err
-    E_TC_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_E_TC_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-class struct_E_1DS_data(Structure):
+E_TC_data = struct_c__SA_E_TC_data
+E_TC_init = _libraries['libascot.so'].E_TC_init
+E_TC_init.restype = ctypes.c_int32
+E_TC_init.argtypes = [ctypes.POINTER(struct_c__SA_E_TC_data), ctypes.c_double * 3]
+E_TC_free = _libraries['libascot.so'].E_TC_free
+E_TC_free.restype = None
+E_TC_free.argtypes = [ctypes.POINTER(struct_c__SA_E_TC_data)]
+E_TC_offload = _libraries['libascot.so'].E_TC_offload
+E_TC_offload.restype = None
+E_TC_offload.argtypes = [ctypes.POINTER(struct_c__SA_E_TC_data)]
+E_TC_eval_E = _libraries['libascot.so'].E_TC_eval_E
+E_TC_eval_E.restype = a5err
+E_TC_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_E_TC_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+class struct_c__SA_E_1DS_data(Structure):
     pass
 
-class struct_interp1D_data(Structure):
+class struct_c__SA_interp1D_data(Structure):
     pass
 
-struct_interp1D_data._pack_ = 1 # source:False
-struct_interp1D_data._fields_ = [
+struct_c__SA_interp1D_data._pack_ = 1 # source:False
+struct_c__SA_interp1D_data._fields_ = [
     ('n_x', ctypes.c_int32),
     ('bc_x', ctypes.c_int32),
     ('x_min', ctypes.c_double),
@@ -709,36 +535,24 @@ struct_interp1D_data._fields_ = [
     ('c', ctypes.POINTER(ctypes.c_double)),
 ]
 
-struct_E_1DS_data._pack_ = 1 # source:False
-struct_E_1DS_data._fields_ = [
-    ('dV', struct_interp1D_data),
+struct_c__SA_E_1DS_data._pack_ = 1 # source:False
+struct_c__SA_E_1DS_data._fields_ = [
+    ('dV', struct_c__SA_interp1D_data),
 ]
 
-E_1DS_data = struct_E_1DS_data
-try:
-    E_1DS_init = _libraries['libascot.so'].E_1DS_init
-    E_1DS_init.restype = ctypes.c_int32
-    E_1DS_init.argtypes = [ctypes.POINTER(struct_E_1DS_data), ctypes.c_int32, real, real, real, ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    E_1DS_free = _libraries['libascot.so'].E_1DS_free
-    E_1DS_free.restype = None
-    E_1DS_free.argtypes = [ctypes.POINTER(struct_E_1DS_data)]
-except AttributeError:
-    pass
-try:
-    E_1DS_offload = _libraries['libascot.so'].E_1DS_offload
-    E_1DS_offload.restype = None
-    E_1DS_offload.argtypes = [ctypes.POINTER(struct_E_1DS_data)]
-except AttributeError:
-    pass
-try:
-    E_1DS_eval_E = _libraries['libascot.so'].E_1DS_eval_E
-    E_1DS_eval_E.restype = a5err
-    E_1DS_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_E_1DS_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
+E_1DS_data = struct_c__SA_E_1DS_data
+E_1DS_init = _libraries['libascot.so'].E_1DS_init
+E_1DS_init.restype = ctypes.c_int32
+E_1DS_init.argtypes = [ctypes.POINTER(struct_c__SA_E_1DS_data), ctypes.c_int32, real, real, real, ctypes.POINTER(ctypes.c_double)]
+E_1DS_free = _libraries['libascot.so'].E_1DS_free
+E_1DS_free.restype = None
+E_1DS_free.argtypes = [ctypes.POINTER(struct_c__SA_E_1DS_data)]
+E_1DS_offload = _libraries['libascot.so'].E_1DS_offload
+E_1DS_offload.restype = None
+E_1DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_E_1DS_data)]
+E_1DS_eval_E = _libraries['libascot.so'].E_1DS_eval_E
+E_1DS_eval_E.restype = a5err
+E_1DS_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_E_1DS_data), ctypes.POINTER(struct_c__SA_B_field_data)]
 
 # values for enumeration 'E_field_type'
 E_field_type__enumvalues = {
@@ -748,41 +562,32 @@ E_field_type__enumvalues = {
 E_field_type_TC = 0
 E_field_type_1DS = 1
 E_field_type = ctypes.c_uint32 # enum
-class struct_E_field_data(Structure):
+class struct_c__SA_E_field_data(Structure):
     pass
 
-struct_E_field_data._pack_ = 1 # source:False
-struct_E_field_data._fields_ = [
+struct_c__SA_E_field_data._pack_ = 1 # source:False
+struct_c__SA_E_field_data._fields_ = [
     ('type', E_field_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('ETC', E_TC_data),
     ('E1DS', E_1DS_data),
 ]
 
-E_field_data = struct_E_field_data
-try:
-    E_field_free = _libraries['libascot.so'].E_field_free
-    E_field_free.restype = None
-    E_field_free.argtypes = [ctypes.POINTER(struct_E_field_data)]
-except AttributeError:
-    pass
-try:
-    E_field_offload = _libraries['libascot.so'].E_field_offload
-    E_field_offload.restype = None
-    E_field_offload.argtypes = [ctypes.POINTER(struct_E_field_data)]
-except AttributeError:
-    pass
-try:
-    E_field_eval_E = _libraries['libascot.so'].E_field_eval_E
-    E_field_eval_E.restype = a5err
-    E_field_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, real, ctypes.POINTER(struct_E_field_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-class struct_particle_state(Structure):
+E_field_data = struct_c__SA_E_field_data
+E_field_free = _libraries['libascot.so'].E_field_free
+E_field_free.restype = None
+E_field_free.argtypes = [ctypes.POINTER(struct_c__SA_E_field_data)]
+E_field_offload = _libraries['libascot.so'].E_field_offload
+E_field_offload.restype = None
+E_field_offload.argtypes = [ctypes.POINTER(struct_c__SA_E_field_data)]
+E_field_eval_E = _libraries['libascot.so'].E_field_eval_E
+E_field_eval_E.restype = a5err
+E_field_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, real, ctypes.POINTER(struct_c__SA_E_field_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+class struct_c__SA_particle_state(Structure):
     pass
 
-struct_particle_state._pack_ = 1 # source:False
-struct_particle_state._fields_ = [
+struct_c__SA_particle_state._pack_ = 1 # source:False
+struct_c__SA_particle_state._fields_ = [
     ('r', ctypes.c_double),
     ('phi', ctypes.c_double),
     ('z', ctypes.c_double),
@@ -823,12 +628,12 @@ struct_particle_state._fields_ = [
     ('err', ctypes.c_uint64),
 ]
 
-particle_state = struct_particle_state
-class struct_particle(Structure):
+particle_state = struct_c__SA_particle_state
+class struct_c__SA_particle(Structure):
     pass
 
-struct_particle._pack_ = 1 # source:False
-struct_particle._fields_ = [
+struct_c__SA_particle._pack_ = 1 # source:False
+struct_c__SA_particle._fields_ = [
     ('r', ctypes.c_double),
     ('phi', ctypes.c_double),
     ('z', ctypes.c_double),
@@ -844,12 +649,12 @@ struct_particle._fields_ = [
     ('id', ctypes.c_int64),
 ]
 
-particle = struct_particle
-class struct_particle_gc(Structure):
+particle = struct_c__SA_particle
+class struct_c__SA_particle_gc(Structure):
     pass
 
-struct_particle_gc._pack_ = 1 # source:False
-struct_particle_gc._fields_ = [
+struct_c__SA_particle_gc._pack_ = 1 # source:False
+struct_c__SA_particle_gc._fields_ = [
     ('r', ctypes.c_double),
     ('phi', ctypes.c_double),
     ('z', ctypes.c_double),
@@ -865,12 +670,12 @@ struct_particle_gc._fields_ = [
     ('id', ctypes.c_int64),
 ]
 
-particle_gc = struct_particle_gc
-class struct_particle_ml(Structure):
+particle_gc = struct_c__SA_particle_gc
+class struct_c__SA_particle_ml(Structure):
     pass
 
-struct_particle_ml._pack_ = 1 # source:False
-struct_particle_ml._fields_ = [
+struct_c__SA_particle_ml._pack_ = 1 # source:False
+struct_c__SA_particle_ml._fields_ = [
     ('r', ctypes.c_double),
     ('phi', ctypes.c_double),
     ('z', ctypes.c_double),
@@ -880,20 +685,20 @@ struct_particle_ml._fields_ = [
     ('id', ctypes.c_int64),
 ]
 
-particle_ml = struct_particle_ml
-class struct_particle_queue(Structure):
+particle_ml = struct_c__SA_particle_ml
+class struct_c__SA_particle_queue(Structure):
     pass
 
-struct_particle_queue._pack_ = 1 # source:False
-struct_particle_queue._fields_ = [
+struct_c__SA_particle_queue._pack_ = 1 # source:False
+struct_c__SA_particle_queue._fields_ = [
     ('n', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
-    ('p', ctypes.POINTER(ctypes.POINTER(struct_particle_state))),
+    ('p', ctypes.POINTER(ctypes.POINTER(struct_c__SA_particle_state))),
     ('next', ctypes.c_int32),
     ('finished', ctypes.c_int32),
 ]
 
-particle_queue = struct_particle_queue
+particle_queue = struct_c__SA_particle_queue
 
 # values for enumeration 'input_particle_type'
 input_particle_type__enumvalues = {
@@ -907,10 +712,10 @@ input_particle_type_gc = 1
 input_particle_type_ml = 2
 input_particle_type_s = 3
 input_particle_type = ctypes.c_uint32 # enum
-class struct_input_particle(Structure):
+class struct_c__SA_input_particle(Structure):
     pass
 
-class union_input_particle_0(Union):
+class union_c__SA_input_particle_0(Union):
     _pack_ = 1 # source:False
     _fields_ = [
     ('p', particle),
@@ -919,20 +724,20 @@ class union_input_particle_0(Union):
     ('p_s', particle_state),
      ]
 
-struct_input_particle._pack_ = 1 # source:False
-struct_input_particle._anonymous_ = ('_0',)
-struct_input_particle._fields_ = [
+struct_c__SA_input_particle._pack_ = 1 # source:False
+struct_c__SA_input_particle._anonymous_ = ('_0',)
+struct_c__SA_input_particle._fields_ = [
     ('type', input_particle_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
-    ('_0', union_input_particle_0),
+    ('_0', union_c__SA_input_particle_0),
 ]
 
-input_particle = struct_input_particle
-class struct_particle_simd_fo(Structure):
+input_particle = struct_c__SA_input_particle
+class struct_c__SA_particle_simd_fo(Structure):
     pass
 
-struct_particle_simd_fo._pack_ = 1 # source:False
-struct_particle_simd_fo._fields_ = [
+struct_c__SA_particle_simd_fo._pack_ = 1 # source:False
+struct_c__SA_particle_simd_fo._fields_ = [
     ('r', ctypes.POINTER(ctypes.c_double)),
     ('phi', ctypes.POINTER(ctypes.c_double)),
     ('z', ctypes.POINTER(ctypes.c_double)),
@@ -971,12 +776,12 @@ struct_particle_simd_fo._fields_ = [
     ('n_mrk', ctypes.c_uint64),
 ]
 
-particle_simd_fo = struct_particle_simd_fo
-class struct_particle_simd_gc(Structure):
+particle_simd_fo = struct_c__SA_particle_simd_fo
+class struct_c__SA_particle_simd_gc(Structure):
     pass
 
-struct_particle_simd_gc._pack_ = 1 # source:False
-struct_particle_simd_gc._fields_ = [
+struct_c__SA_particle_simd_gc._pack_ = 1 # source:False
+struct_c__SA_particle_simd_gc._fields_ = [
     ('r', ctypes.c_double * 16),
     ('phi', ctypes.c_double * 16),
     ('z', ctypes.c_double * 16),
@@ -1012,12 +817,12 @@ struct_particle_simd_gc._fields_ = [
     ('index', ctypes.c_int64 * 16),
 ]
 
-particle_simd_gc = struct_particle_simd_gc
-class struct_particle_simd_ml(Structure):
+particle_simd_gc = struct_c__SA_particle_simd_gc
+class struct_c__SA_particle_simd_ml(Structure):
     pass
 
-struct_particle_simd_ml._pack_ = 1 # source:False
-struct_particle_simd_ml._fields_ = [
+struct_c__SA_particle_simd_ml._pack_ = 1 # source:False
+struct_c__SA_particle_simd_ml._fields_ = [
     ('r', ctypes.c_double * 16),
     ('phi', ctypes.c_double * 16),
     ('z', ctypes.c_double * 16),
@@ -1048,150 +853,81 @@ struct_particle_simd_ml._fields_ = [
     ('index', ctypes.c_int64 * 16),
 ]
 
-particle_simd_ml = struct_particle_simd_ml
-try:
-    particle_allocate_fo = _libraries['libascot.so'].particle_allocate_fo
-    particle_allocate_fo.restype = None
-    particle_allocate_fo.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_to_fo_dummy = _libraries['libascot.so'].particle_to_fo_dummy
-    particle_to_fo_dummy.restype = None
-    particle_to_fo_dummy.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_to_gc_dummy = _libraries['libascot.so'].particle_to_gc_dummy
-    particle_to_gc_dummy.restype = None
-    particle_to_gc_dummy.argtypes = [ctypes.POINTER(struct_particle_simd_gc), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_to_ml_dummy = _libraries['libascot.so'].particle_to_ml_dummy
-    particle_to_ml_dummy.restype = None
-    particle_to_ml_dummy.argtypes = [ctypes.POINTER(struct_particle_simd_ml), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_cycle_fo = _libraries['libascot.so'].particle_cycle_fo
-    particle_cycle_fo.restype = ctypes.c_int32
-    particle_cycle_fo.argtypes = [ctypes.POINTER(struct_particle_queue), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    particle_cycle_gc = _libraries['libascot.so'].particle_cycle_gc
-    particle_cycle_gc.restype = ctypes.c_int32
-    particle_cycle_gc.argtypes = [ctypes.POINTER(struct_particle_queue), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    particle_cycle_ml = _libraries['libascot.so'].particle_cycle_ml
-    particle_cycle_ml.restype = ctypes.c_int32
-    particle_cycle_ml.argtypes = [ctypes.POINTER(struct_particle_queue), ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    particle_input_to_state = _libraries['libascot.so'].particle_input_to_state
-    particle_input_to_state.restype = None
-    particle_input_to_state.argtypes = [ctypes.POINTER(struct_input_particle), ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_input_p_to_state = _libraries['libascot.so'].particle_input_p_to_state
-    particle_input_p_to_state.restype = a5err
-    particle_input_p_to_state.argtypes = [ctypes.POINTER(struct_particle), ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_input_gc_to_state = _libraries['libascot.so'].particle_input_gc_to_state
-    particle_input_gc_to_state.restype = a5err
-    particle_input_gc_to_state.argtypes = [ctypes.POINTER(struct_particle_gc), ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_input_ml_to_state = _libraries['libascot.so'].particle_input_ml_to_state
-    particle_input_ml_to_state.restype = a5err
-    particle_input_ml_to_state.argtypes = [ctypes.POINTER(struct_particle_ml), ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_offload_fo = _libraries['libascot.so'].particle_offload_fo
-    particle_offload_fo.restype = None
-    particle_offload_fo.argtypes = [ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    particle_onload_fo = _libraries['libascot.so'].particle_onload_fo
-    particle_onload_fo.restype = None
-    particle_onload_fo.argtypes = [ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    particle_state_to_fo = _libraries['libascot.so'].particle_state_to_fo
-    particle_state_to_fo.restype = a5err
-    particle_state_to_fo.argtypes = [ctypes.POINTER(struct_particle_state), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_fo_to_state = _libraries['libascot.so'].particle_fo_to_state
-    particle_fo_to_state.restype = None
-    particle_fo_to_state.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_state_to_gc = _libraries['libascot.so'].particle_state_to_gc
-    particle_state_to_gc.restype = a5err
-    particle_state_to_gc.argtypes = [ctypes.POINTER(struct_particle_state), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_gc_to_state = _libraries['libascot.so'].particle_gc_to_state
-    particle_gc_to_state.restype = None
-    particle_gc_to_state.argtypes = [ctypes.POINTER(struct_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_state_to_ml = _libraries['libascot.so'].particle_state_to_ml
-    particle_state_to_ml.restype = a5err
-    particle_state_to_ml.argtypes = [ctypes.POINTER(struct_particle_state), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_ml_to_state = _libraries['libascot.so'].particle_ml_to_state
-    particle_ml_to_state.restype = None
-    particle_ml_to_state.argtypes = [ctypes.POINTER(struct_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_fo_to_gc = _libraries['libascot.so'].particle_fo_to_gc
-    particle_fo_to_gc.restype = ctypes.c_int32
-    particle_fo_to_gc.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    particle_copy_fo = _libraries['libascot.so'].particle_copy_fo
-    particle_copy_fo.restype = None
-    particle_copy_fo.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_fo), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_copy_gc = _libraries['libascot.so'].particle_copy_gc
-    particle_copy_gc.restype = None
-    particle_copy_gc.argtypes = [ctypes.POINTER(struct_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_gc), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    particle_copy_ml = _libraries['libascot.so'].particle_copy_ml
-    particle_copy_ml.restype = None
-    particle_copy_ml.argtypes = [ctypes.POINTER(struct_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_particle_simd_ml), ctypes.c_int32]
-except AttributeError:
-    pass
-class struct_dist_5D_data(Structure):
+particle_simd_ml = struct_c__SA_particle_simd_ml
+particle_allocate_fo = _libraries['libascot.so'].particle_allocate_fo
+particle_allocate_fo.restype = None
+particle_allocate_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32]
+particle_to_fo_dummy = _libraries['libascot.so'].particle_to_fo_dummy
+particle_to_fo_dummy.restype = None
+particle_to_fo_dummy.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32]
+particle_to_gc_dummy = _libraries['libascot.so'].particle_to_gc_dummy
+particle_to_gc_dummy.restype = None
+particle_to_gc_dummy.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32]
+particle_to_ml_dummy = _libraries['libascot.so'].particle_to_ml_dummy
+particle_to_ml_dummy.restype = None
+particle_to_ml_dummy.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.c_int32]
+particle_cycle_fo = _libraries['libascot.so'].particle_cycle_fo
+particle_cycle_fo.restype = ctypes.c_int32
+particle_cycle_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_queue), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(ctypes.c_int32)]
+particle_cycle_gc = _libraries['libascot.so'].particle_cycle_gc
+particle_cycle_gc.restype = ctypes.c_int32
+particle_cycle_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_queue), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(ctypes.c_int32)]
+particle_cycle_ml = _libraries['libascot.so'].particle_cycle_ml
+particle_cycle_ml.restype = ctypes.c_int32
+particle_cycle_ml.argtypes = [ctypes.POINTER(struct_c__SA_particle_queue), ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(ctypes.c_int32)]
+particle_input_to_state = _libraries['libascot.so'].particle_input_to_state
+particle_input_to_state.restype = None
+particle_input_to_state.argtypes = [ctypes.POINTER(struct_c__SA_input_particle), ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_input_p_to_state = _libraries['libascot.so'].particle_input_p_to_state
+particle_input_p_to_state.restype = a5err
+particle_input_p_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle), ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_input_gc_to_state = _libraries['libascot.so'].particle_input_gc_to_state
+particle_input_gc_to_state.restype = a5err
+particle_input_gc_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle_gc), ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_input_ml_to_state = _libraries['libascot.so'].particle_input_ml_to_state
+particle_input_ml_to_state.restype = a5err
+particle_input_ml_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle_ml), ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_offload_fo = _libraries['libascot.so'].particle_offload_fo
+particle_offload_fo.restype = None
+particle_offload_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+particle_onload_fo = _libraries['libascot.so'].particle_onload_fo
+particle_onload_fo.restype = None
+particle_onload_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+particle_state_to_fo = _libraries['libascot.so'].particle_state_to_fo
+particle_state_to_fo.restype = a5err
+particle_state_to_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_fo_to_state = _libraries['libascot.so'].particle_fo_to_state
+particle_fo_to_state.restype = None
+particle_fo_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_state_to_gc = _libraries['libascot.so'].particle_state_to_gc
+particle_state_to_gc.restype = a5err
+particle_state_to_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_gc_to_state = _libraries['libascot.so'].particle_gc_to_state
+particle_gc_to_state.restype = None
+particle_gc_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_state_to_ml = _libraries['libascot.so'].particle_state_to_ml
+particle_state_to_ml.restype = a5err
+particle_state_to_ml.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_ml_to_state = _libraries['libascot.so'].particle_ml_to_state
+particle_ml_to_state.restype = None
+particle_ml_to_state.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_fo_to_gc = _libraries['libascot.so'].particle_fo_to_gc
+particle_fo_to_gc.restype = ctypes.c_int32
+particle_fo_to_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_B_field_data)]
+particle_copy_fo = _libraries['libascot.so'].particle_copy_fo
+particle_copy_fo.restype = None
+particle_copy_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32]
+particle_copy_gc = _libraries['libascot.so'].particle_copy_gc
+particle_copy_gc.restype = None
+particle_copy_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32]
+particle_copy_ml = _libraries['libascot.so'].particle_copy_ml
+particle_copy_ml.restype = None
+particle_copy_ml.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.c_int32]
+class struct_c__SA_dist_5D_data(Structure):
     pass
 
-struct_dist_5D_data._pack_ = 1 # source:False
-struct_dist_5D_data._fields_ = [
+struct_c__SA_dist_5D_data._pack_ = 1 # source:False
+struct_c__SA_dist_5D_data._fields_ = [
     ('n_r', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min_r', ctypes.c_double),
@@ -1229,55 +965,34 @@ struct_dist_5D_data._fields_ = [
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-dist_5D_data = struct_dist_5D_data
+dist_5D_data = struct_c__SA_dist_5D_data
 size_t = ctypes.c_uint64
-try:
-    dist_5D_index = _libraries['libascot.so'].dist_5D_index
-    dist_5D_index.restype = size_t
-    dist_5D_index.argtypes = [ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, size_t, size_t, size_t, size_t, size_t, size_t]
-except AttributeError:
-    pass
-try:
-    dist_5D_init = _libraries['libascot.so'].dist_5D_init
-    dist_5D_init.restype = ctypes.c_int32
-    dist_5D_init.argtypes = [ctypes.POINTER(struct_dist_5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_5D_free = _libraries['libascot.so'].dist_5D_free
-    dist_5D_free.restype = None
-    dist_5D_free.argtypes = [ctypes.POINTER(struct_dist_5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_5D_offload = _libraries['libascot.so'].dist_5D_offload
-    dist_5D_offload.restype = None
-    dist_5D_offload.argtypes = [ctypes.POINTER(struct_dist_5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_5D_onload = _libraries['libascot.so'].dist_5D_onload
-    dist_5D_onload.restype = None
-    dist_5D_onload.argtypes = [ctypes.POINTER(struct_dist_5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_5D_update_fo = _libraries['libascot.so'].dist_5D_update_fo
-    dist_5D_update_fo.restype = None
-    dist_5D_update_fo.argtypes = [ctypes.POINTER(struct_dist_5D_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    dist_5D_update_gc = _libraries['libascot.so'].dist_5D_update_gc
-    dist_5D_update_gc.restype = None
-    dist_5D_update_gc.argtypes = [ctypes.POINTER(struct_dist_5D_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-class struct_dist_6D_data(Structure):
+dist_5D_index = _libraries['libascot.so'].dist_5D_index
+dist_5D_index.restype = size_t
+dist_5D_index.argtypes = [ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, size_t, size_t, size_t, size_t, size_t, size_t]
+dist_5D_init = _libraries['libascot.so'].dist_5D_init
+dist_5D_init.restype = ctypes.c_int32
+dist_5D_init.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data)]
+dist_5D_free = _libraries['libascot.so'].dist_5D_free
+dist_5D_free.restype = None
+dist_5D_free.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data)]
+dist_5D_offload = _libraries['libascot.so'].dist_5D_offload
+dist_5D_offload.restype = None
+dist_5D_offload.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data)]
+dist_5D_onload = _libraries['libascot.so'].dist_5D_onload
+dist_5D_onload.restype = None
+dist_5D_onload.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data)]
+dist_5D_update_fo = _libraries['libascot.so'].dist_5D_update_fo
+dist_5D_update_fo.restype = None
+dist_5D_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+dist_5D_update_gc = _libraries['libascot.so'].dist_5D_update_gc
+dist_5D_update_gc.restype = None
+dist_5D_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_dist_5D_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+class struct_c__SA_dist_6D_data(Structure):
     pass
 
-struct_dist_6D_data._pack_ = 1 # source:False
-struct_dist_6D_data._fields_ = [
+struct_c__SA_dist_6D_data._pack_ = 1 # source:False
+struct_c__SA_dist_6D_data._fields_ = [
     ('n_r', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min_r', ctypes.c_double),
@@ -1320,48 +1035,30 @@ struct_dist_6D_data._fields_ = [
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-dist_6D_data = struct_dist_6D_data
-try:
-    dist_6D_init = _libraries['libascot.so'].dist_6D_init
-    dist_6D_init.restype = ctypes.c_int32
-    dist_6D_init.argtypes = [ctypes.POINTER(struct_dist_6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_6D_free = _libraries['libascot.so'].dist_6D_free
-    dist_6D_free.restype = None
-    dist_6D_free.argtypes = [ctypes.POINTER(struct_dist_6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_6D_offload = _libraries['libascot.so'].dist_6D_offload
-    dist_6D_offload.restype = None
-    dist_6D_offload.argtypes = [ctypes.POINTER(struct_dist_6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_6D_onload = _libraries['libascot.so'].dist_6D_onload
-    dist_6D_onload.restype = None
-    dist_6D_onload.argtypes = [ctypes.POINTER(struct_dist_6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_6D_update_fo = _libraries['libascot.so'].dist_6D_update_fo
-    dist_6D_update_fo.restype = None
-    dist_6D_update_fo.argtypes = [ctypes.POINTER(struct_dist_6D_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    dist_6D_update_gc = _libraries['libascot.so'].dist_6D_update_gc
-    dist_6D_update_gc.restype = None
-    dist_6D_update_gc.argtypes = [ctypes.POINTER(struct_dist_6D_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-class struct_dist_rho5D_data(Structure):
+dist_6D_data = struct_c__SA_dist_6D_data
+dist_6D_init = _libraries['libascot.so'].dist_6D_init
+dist_6D_init.restype = ctypes.c_int32
+dist_6D_init.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data)]
+dist_6D_free = _libraries['libascot.so'].dist_6D_free
+dist_6D_free.restype = None
+dist_6D_free.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data)]
+dist_6D_offload = _libraries['libascot.so'].dist_6D_offload
+dist_6D_offload.restype = None
+dist_6D_offload.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data)]
+dist_6D_onload = _libraries['libascot.so'].dist_6D_onload
+dist_6D_onload.restype = None
+dist_6D_onload.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data)]
+dist_6D_update_fo = _libraries['libascot.so'].dist_6D_update_fo
+dist_6D_update_fo.restype = None
+dist_6D_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+dist_6D_update_gc = _libraries['libascot.so'].dist_6D_update_gc
+dist_6D_update_gc.restype = None
+dist_6D_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_dist_6D_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+class struct_c__SA_dist_rho5D_data(Structure):
     pass
 
-struct_dist_rho5D_data._pack_ = 1 # source:False
-struct_dist_rho5D_data._fields_ = [
+struct_c__SA_dist_rho5D_data._pack_ = 1 # source:False
+struct_c__SA_dist_rho5D_data._fields_ = [
     ('n_rho', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min_rho', ctypes.c_double),
@@ -1399,48 +1096,30 @@ struct_dist_rho5D_data._fields_ = [
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-dist_rho5D_data = struct_dist_rho5D_data
-try:
-    dist_rho5D_init = _libraries['libascot.so'].dist_rho5D_init
-    dist_rho5D_init.restype = ctypes.c_int32
-    dist_rho5D_init.argtypes = [ctypes.POINTER(struct_dist_rho5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho5D_free = _libraries['libascot.so'].dist_rho5D_free
-    dist_rho5D_free.restype = None
-    dist_rho5D_free.argtypes = [ctypes.POINTER(struct_dist_rho5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho5D_offload = _libraries['libascot.so'].dist_rho5D_offload
-    dist_rho5D_offload.restype = None
-    dist_rho5D_offload.argtypes = [ctypes.POINTER(struct_dist_rho5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho5D_onload = _libraries['libascot.so'].dist_rho5D_onload
-    dist_rho5D_onload.restype = None
-    dist_rho5D_onload.argtypes = [ctypes.POINTER(struct_dist_rho5D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho5D_update_fo = _libraries['libascot.so'].dist_rho5D_update_fo
-    dist_rho5D_update_fo.restype = None
-    dist_rho5D_update_fo.argtypes = [ctypes.POINTER(struct_dist_rho5D_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    dist_rho5D_update_gc = _libraries['libascot.so'].dist_rho5D_update_gc
-    dist_rho5D_update_gc.restype = None
-    dist_rho5D_update_gc.argtypes = [ctypes.POINTER(struct_dist_rho5D_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-class struct_dist_rho6D_data(Structure):
+dist_rho5D_data = struct_c__SA_dist_rho5D_data
+dist_rho5D_init = _libraries['libascot.so'].dist_rho5D_init
+dist_rho5D_init.restype = ctypes.c_int32
+dist_rho5D_init.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data)]
+dist_rho5D_free = _libraries['libascot.so'].dist_rho5D_free
+dist_rho5D_free.restype = None
+dist_rho5D_free.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data)]
+dist_rho5D_offload = _libraries['libascot.so'].dist_rho5D_offload
+dist_rho5D_offload.restype = None
+dist_rho5D_offload.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data)]
+dist_rho5D_onload = _libraries['libascot.so'].dist_rho5D_onload
+dist_rho5D_onload.restype = None
+dist_rho5D_onload.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data)]
+dist_rho5D_update_fo = _libraries['libascot.so'].dist_rho5D_update_fo
+dist_rho5D_update_fo.restype = None
+dist_rho5D_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+dist_rho5D_update_gc = _libraries['libascot.so'].dist_rho5D_update_gc
+dist_rho5D_update_gc.restype = None
+dist_rho5D_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho5D_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+class struct_c__SA_dist_rho6D_data(Structure):
     pass
 
-struct_dist_rho6D_data._pack_ = 1 # source:False
-struct_dist_rho6D_data._fields_ = [
+struct_c__SA_dist_rho6D_data._pack_ = 1 # source:False
+struct_c__SA_dist_rho6D_data._fields_ = [
     ('n_rho', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min_rho', ctypes.c_double),
@@ -1483,48 +1162,30 @@ struct_dist_rho6D_data._fields_ = [
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-dist_rho6D_data = struct_dist_rho6D_data
-try:
-    dist_rho6D_init = _libraries['libascot.so'].dist_rho6D_init
-    dist_rho6D_init.restype = ctypes.c_int32
-    dist_rho6D_init.argtypes = [ctypes.POINTER(struct_dist_rho6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho6D_free = _libraries['libascot.so'].dist_rho6D_free
-    dist_rho6D_free.restype = None
-    dist_rho6D_free.argtypes = [ctypes.POINTER(struct_dist_rho6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho6D_offload = _libraries['libascot.so'].dist_rho6D_offload
-    dist_rho6D_offload.restype = None
-    dist_rho6D_offload.argtypes = [ctypes.POINTER(struct_dist_rho6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho6D_onload = _libraries['libascot.so'].dist_rho6D_onload
-    dist_rho6D_onload.restype = None
-    dist_rho6D_onload.argtypes = [ctypes.POINTER(struct_dist_rho6D_data)]
-except AttributeError:
-    pass
-try:
-    dist_rho6D_update_fo = _libraries['libascot.so'].dist_rho6D_update_fo
-    dist_rho6D_update_fo.restype = None
-    dist_rho6D_update_fo.argtypes = [ctypes.POINTER(struct_dist_rho6D_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    dist_rho6D_update_gc = _libraries['libascot.so'].dist_rho6D_update_gc
-    dist_rho6D_update_gc.restype = None
-    dist_rho6D_update_gc.argtypes = [ctypes.POINTER(struct_dist_rho6D_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-class struct_dist_COM_data(Structure):
+dist_rho6D_data = struct_c__SA_dist_rho6D_data
+dist_rho6D_init = _libraries['libascot.so'].dist_rho6D_init
+dist_rho6D_init.restype = ctypes.c_int32
+dist_rho6D_init.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data)]
+dist_rho6D_free = _libraries['libascot.so'].dist_rho6D_free
+dist_rho6D_free.restype = None
+dist_rho6D_free.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data)]
+dist_rho6D_offload = _libraries['libascot.so'].dist_rho6D_offload
+dist_rho6D_offload.restype = None
+dist_rho6D_offload.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data)]
+dist_rho6D_onload = _libraries['libascot.so'].dist_rho6D_onload
+dist_rho6D_onload.restype = None
+dist_rho6D_onload.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data)]
+dist_rho6D_update_fo = _libraries['libascot.so'].dist_rho6D_update_fo
+dist_rho6D_update_fo.restype = None
+dist_rho6D_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+dist_rho6D_update_gc = _libraries['libascot.so'].dist_rho6D_update_gc
+dist_rho6D_update_gc.restype = None
+dist_rho6D_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_dist_rho6D_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+class struct_c__SA_dist_COM_data(Structure):
     pass
 
-struct_dist_COM_data._pack_ = 1 # source:False
-struct_dist_COM_data._fields_ = [
+struct_c__SA_dist_COM_data._pack_ = 1 # source:False
+struct_c__SA_dist_COM_data._fields_ = [
     ('n_mu', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min_mu', ctypes.c_double),
@@ -1542,60 +1203,36 @@ struct_dist_COM_data._fields_ = [
     ('histogram', ctypes.POINTER(ctypes.c_double)),
 ]
 
-dist_COM_data = struct_dist_COM_data
-try:
-    dist_COM_init = _libraries['libascot.so'].dist_COM_init
-    dist_COM_init.restype = ctypes.c_int32
-    dist_COM_init.argtypes = [ctypes.POINTER(struct_dist_COM_data)]
-except AttributeError:
-    pass
-try:
-    dist_COM_free = _libraries['libascot.so'].dist_COM_free
-    dist_COM_free.restype = None
-    dist_COM_free.argtypes = [ctypes.POINTER(struct_dist_COM_data)]
-except AttributeError:
-    pass
-try:
-    dist_COM_offload = _libraries['libascot.so'].dist_COM_offload
-    dist_COM_offload.restype = None
-    dist_COM_offload.argtypes = [ctypes.POINTER(struct_dist_COM_data)]
-except AttributeError:
-    pass
-try:
-    dist_COM_onload = _libraries['libascot.so'].dist_COM_onload
-    dist_COM_onload.restype = None
-    dist_COM_onload.argtypes = [ctypes.POINTER(struct_dist_COM_data)]
-except AttributeError:
-    pass
-try:
-    dist_COM_update_fo = _libraries['libascot.so'].dist_COM_update_fo
-    dist_COM_update_fo.restype = None
-    dist_COM_update_fo.argtypes = [ctypes.POINTER(struct_dist_COM_data), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    dist_COM_update_gc = _libraries['libascot.so'].dist_COM_update_gc
-    dist_COM_update_gc.restype = None
-    dist_COM_update_gc.argtypes = [ctypes.POINTER(struct_dist_COM_data), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-try:
-    diag_orb_check_plane_crossing = _libraries['libascot.so'].diag_orb_check_plane_crossing
-    diag_orb_check_plane_crossing.restype = real
-    diag_orb_check_plane_crossing.argtypes = [real, real, real]
-except AttributeError:
-    pass
-try:
-    diag_orb_check_radial_crossing = _libraries['libascot.so'].diag_orb_check_radial_crossing
-    diag_orb_check_radial_crossing.restype = real
-    diag_orb_check_radial_crossing.argtypes = [real, real, real]
-except AttributeError:
-    pass
-class struct_diag_orb_data(Structure):
+dist_COM_data = struct_c__SA_dist_COM_data
+dist_COM_init = _libraries['libascot.so'].dist_COM_init
+dist_COM_init.restype = ctypes.c_int32
+dist_COM_init.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data)]
+dist_COM_free = _libraries['libascot.so'].dist_COM_free
+dist_COM_free.restype = None
+dist_COM_free.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data)]
+dist_COM_offload = _libraries['libascot.so'].dist_COM_offload
+dist_COM_offload.restype = None
+dist_COM_offload.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data)]
+dist_COM_onload = _libraries['libascot.so'].dist_COM_onload
+dist_COM_onload.restype = None
+dist_COM_onload.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data)]
+dist_COM_update_fo = _libraries['libascot.so'].dist_COM_update_fo
+dist_COM_update_fo.restype = None
+dist_COM_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+dist_COM_update_gc = _libraries['libascot.so'].dist_COM_update_gc
+dist_COM_update_gc.restype = None
+dist_COM_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_dist_COM_data), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+diag_orb_check_plane_crossing = _libraries['libascot.so'].diag_orb_check_plane_crossing
+diag_orb_check_plane_crossing.restype = real
+diag_orb_check_plane_crossing.argtypes = [real, real, real]
+diag_orb_check_radial_crossing = _libraries['libascot.so'].diag_orb_check_radial_crossing
+diag_orb_check_radial_crossing.restype = real
+diag_orb_check_radial_crossing.argtypes = [real, real, real]
+class struct_c__SA_diag_orb_data(Structure):
     pass
 
-struct_diag_orb_data._pack_ = 1 # source:False
-struct_diag_orb_data._fields_ = [
+struct_c__SA_diag_orb_data._pack_ = 1 # source:False
+struct_c__SA_diag_orb_data._fields_ = [
     ('id', ctypes.POINTER(ctypes.c_double)),
     ('mileage', ctypes.POINTER(ctypes.c_double)),
     ('r', ctypes.POINTER(ctypes.c_double)),
@@ -1633,37 +1270,22 @@ struct_diag_orb_data._fields_ = [
     ('radialdistances', ctypes.c_double * 30),
 ]
 
-diag_orb_data = struct_diag_orb_data
-try:
-    diag_orb_init = _libraries['libascot.so'].diag_orb_init
-    diag_orb_init.restype = None
-    diag_orb_init.argtypes = [ctypes.POINTER(struct_diag_orb_data)]
-except AttributeError:
-    pass
-try:
-    diag_orb_free = _libraries['libascot.so'].diag_orb_free
-    diag_orb_free.restype = None
-    diag_orb_free.argtypes = [ctypes.POINTER(struct_diag_orb_data)]
-except AttributeError:
-    pass
-try:
-    diag_orb_update_fo = _libraries['libascot.so'].diag_orb_update_fo
-    diag_orb_update_fo.restype = None
-    diag_orb_update_fo.argtypes = [ctypes.POINTER(struct_diag_orb_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    diag_orb_update_gc = _libraries['libascot.so'].diag_orb_update_gc
-    diag_orb_update_gc.restype = None
-    diag_orb_update_gc.argtypes = [ctypes.POINTER(struct_diag_orb_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-try:
-    diag_orb_update_ml = _libraries['libascot.so'].diag_orb_update_ml
-    diag_orb_update_ml.restype = None
-    diag_orb_update_ml.argtypes = [ctypes.POINTER(struct_diag_orb_data), ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_particle_simd_ml)]
-except AttributeError:
-    pass
+diag_orb_data = struct_c__SA_diag_orb_data
+diag_orb_init = _libraries['libascot.so'].diag_orb_init
+diag_orb_init.restype = None
+diag_orb_init.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data)]
+diag_orb_free = _libraries['libascot.so'].diag_orb_free
+diag_orb_free.restype = None
+diag_orb_free.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data)]
+diag_orb_update_fo = _libraries['libascot.so'].diag_orb_update_fo
+diag_orb_update_fo.restype = None
+diag_orb_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+diag_orb_update_gc = _libraries['libascot.so'].diag_orb_update_gc
+diag_orb_update_gc.restype = None
+diag_orb_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+diag_orb_update_ml = _libraries['libascot.so'].diag_orb_update_ml
+diag_orb_update_ml.restype = None
+diag_orb_update_ml.argtypes = [ctypes.POINTER(struct_c__SA_diag_orb_data), ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_particle_simd_ml)]
 class struct_diag_transcoef_link(Structure):
     pass
 
@@ -1677,11 +1299,11 @@ struct_diag_transcoef_link._fields_ = [
 ]
 
 diag_transcoef_link = struct_diag_transcoef_link
-class struct_diag_transcoef_data(Structure):
+class struct_c__SA_diag_transcoef_data(Structure):
     pass
 
-struct_diag_transcoef_data._pack_ = 1 # source:False
-struct_diag_transcoef_data._fields_ = [
+struct_c__SA_diag_transcoef_data._pack_ = 1 # source:False
+struct_c__SA_diag_transcoef_data._fields_ = [
     ('Nmrk', ctypes.c_int64),
     ('Navg', ctypes.c_int32),
     ('recordrho', ctypes.c_int32),
@@ -1692,42 +1314,27 @@ struct_diag_transcoef_data._fields_ = [
     ('Dcoef', ctypes.POINTER(ctypes.c_double)),
 ]
 
-diag_transcoef_data = struct_diag_transcoef_data
-try:
-    diag_transcoef_init = _libraries['libascot.so'].diag_transcoef_init
-    diag_transcoef_init.restype = None
-    diag_transcoef_init.argtypes = [ctypes.POINTER(struct_diag_transcoef_data)]
-except AttributeError:
-    pass
-try:
-    diag_transcoef_free = _libraries['libascot.so'].diag_transcoef_free
-    diag_transcoef_free.restype = None
-    diag_transcoef_free.argtypes = [ctypes.POINTER(struct_diag_transcoef_data)]
-except AttributeError:
-    pass
-try:
-    diag_transcoef_update_fo = _libraries['libascot.so'].diag_transcoef_update_fo
-    diag_transcoef_update_fo.restype = None
-    diag_transcoef_update_fo.argtypes = [ctypes.POINTER(struct_diag_transcoef_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    diag_transcoef_update_gc = _libraries['libascot.so'].diag_transcoef_update_gc
-    diag_transcoef_update_gc.restype = None
-    diag_transcoef_update_gc.argtypes = [ctypes.POINTER(struct_diag_transcoef_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-try:
-    diag_transcoef_update_ml = _libraries['libascot.so'].diag_transcoef_update_ml
-    diag_transcoef_update_ml.restype = None
-    diag_transcoef_update_ml.argtypes = [ctypes.POINTER(struct_diag_transcoef_data), ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_particle_simd_ml)]
-except AttributeError:
-    pass
-class struct_diag_data(Structure):
+diag_transcoef_data = struct_c__SA_diag_transcoef_data
+diag_transcoef_init = _libraries['libascot.so'].diag_transcoef_init
+diag_transcoef_init.restype = None
+diag_transcoef_init.argtypes = [ctypes.POINTER(struct_c__SA_diag_transcoef_data)]
+diag_transcoef_free = _libraries['libascot.so'].diag_transcoef_free
+diag_transcoef_free.restype = None
+diag_transcoef_free.argtypes = [ctypes.POINTER(struct_c__SA_diag_transcoef_data)]
+diag_transcoef_update_fo = _libraries['libascot.so'].diag_transcoef_update_fo
+diag_transcoef_update_fo.restype = None
+diag_transcoef_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_diag_transcoef_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+diag_transcoef_update_gc = _libraries['libascot.so'].diag_transcoef_update_gc
+diag_transcoef_update_gc.restype = None
+diag_transcoef_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_diag_transcoef_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+diag_transcoef_update_ml = _libraries['libascot.so'].diag_transcoef_update_ml
+diag_transcoef_update_ml.restype = None
+diag_transcoef_update_ml.argtypes = [ctypes.POINTER(struct_c__SA_diag_transcoef_data), ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_particle_simd_ml)]
+class struct_c__SA_diag_data(Structure):
     pass
 
-struct_diag_data._pack_ = 1 # source:False
-struct_diag_data._fields_ = [
+struct_c__SA_diag_data._pack_ = 1 # source:False
+struct_c__SA_diag_data._fields_ = [
     ('diagorb_collect', ctypes.c_int32),
     ('dist5D_collect', ctypes.c_int32),
     ('dist6D_collect', ctypes.c_int32),
@@ -1745,96 +1352,54 @@ struct_diag_data._fields_ = [
     ('diagtrcof', diag_transcoef_data),
 ]
 
-diag_data = struct_diag_data
-try:
-    diag_init = _libraries['libascot.so'].diag_init
-    diag_init.restype = ctypes.c_int32
-    diag_init.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    diag_free = _libraries['libascot.so'].diag_free
-    diag_free.restype = None
-    diag_free.argtypes = [ctypes.POINTER(struct_diag_data)]
-except AttributeError:
-    pass
-try:
-    diag_offload = _libraries['libascot.so'].diag_offload
-    diag_offload.restype = None
-    diag_offload.argtypes = [ctypes.POINTER(struct_diag_data)]
-except AttributeError:
-    pass
-try:
-    diag_onload = _libraries['libascot.so'].diag_onload
-    diag_onload.restype = None
-    diag_onload.argtypes = [ctypes.POINTER(struct_diag_data)]
-except AttributeError:
-    pass
-try:
-    diag_sum = _libraries['libascot.so'].diag_sum
-    diag_sum.restype = None
-    diag_sum.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.POINTER(struct_diag_data)]
-except AttributeError:
-    pass
-try:
-    diag_update_fo = _libraries['libascot.so'].diag_update_fo
-    diag_update_fo.restype = None
-    diag_update_fo.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    diag_update_gc = _libraries['libascot.so'].diag_update_gc
-    diag_update_gc.restype = None
-    diag_update_gc.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.POINTER(struct_B_field_data), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
-try:
-    diag_update_ml = _libraries['libascot.so'].diag_update_ml
-    diag_update_ml.restype = None
-    diag_update_ml.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_particle_simd_ml)]
-except AttributeError:
-    pass
-try:
-    mpi_interface_barrier = _libraries['libascot.so'].mpi_interface_barrier
-    mpi_interface_barrier.restype = None
-    mpi_interface_barrier.argtypes = []
-except AttributeError:
-    pass
-try:
-    mpi_interface_init = _libraries['libascot.so'].mpi_interface_init
-    mpi_interface_init.restype = None
-    mpi_interface_init.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.POINTER(ctypes.c_char)), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    mpi_interface_finalize = _libraries['libascot.so'].mpi_interface_finalize
-    mpi_interface_finalize.restype = None
-    mpi_interface_finalize.argtypes = [ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    mpi_my_particles = _libraries['libascot.so'].mpi_my_particles
-    mpi_my_particles.restype = None
-    mpi_my_particles.argtypes = [ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    mpi_gather_particlestate = _libraries['libascot.so'].mpi_gather_particlestate
-    mpi_gather_particlestate.restype = None
-    mpi_gather_particlestate.argtypes = [ctypes.POINTER(struct_particle_state), ctypes.POINTER(ctypes.POINTER(struct_particle_state)), ctypes.POINTER(ctypes.c_int32), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    mpi_gather_diag = _libraries['libascot.so'].mpi_gather_diag
-    mpi_gather_diag.restype = None
-    mpi_gather_diag.argtypes = [ctypes.POINTER(struct_diag_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
-except AttributeError:
-    pass
-class struct_plasma_1D_data(Structure):
+diag_data = struct_c__SA_diag_data
+diag_init = _libraries['libascot.so'].diag_init
+diag_init.restype = ctypes.c_int32
+diag_init.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.c_int32]
+diag_free = _libraries['libascot.so'].diag_free
+diag_free.restype = None
+diag_free.argtypes = [ctypes.POINTER(struct_c__SA_diag_data)]
+diag_offload = _libraries['libascot.so'].diag_offload
+diag_offload.restype = None
+diag_offload.argtypes = [ctypes.POINTER(struct_c__SA_diag_data)]
+diag_onload = _libraries['libascot.so'].diag_onload
+diag_onload.restype = None
+diag_onload.argtypes = [ctypes.POINTER(struct_c__SA_diag_data)]
+diag_sum = _libraries['libascot.so'].diag_sum
+diag_sum.restype = None
+diag_sum.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.POINTER(struct_c__SA_diag_data)]
+diag_update_fo = _libraries['libascot.so'].diag_update_fo
+diag_update_fo.restype = None
+diag_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+diag_update_gc = _libraries['libascot.so'].diag_update_gc
+diag_update_gc.restype = None
+diag_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+diag_update_ml = _libraries['libascot.so'].diag_update_ml
+diag_update_ml.restype = None
+diag_update_ml.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_particle_simd_ml)]
+mpi_interface_barrier = _libraries['libascot.so'].mpi_interface_barrier
+mpi_interface_barrier.restype = None
+mpi_interface_barrier.argtypes = []
+mpi_interface_init = _libraries['libascot.so'].mpi_interface_init
+mpi_interface_init.restype = None
+mpi_interface_init.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.POINTER(ctypes.c_char)), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32)]
+mpi_interface_finalize = _libraries['libascot.so'].mpi_interface_finalize
+mpi_interface_finalize.restype = None
+mpi_interface_finalize.argtypes = [ctypes.c_int32]
+mpi_my_particles = _libraries['libascot.so'].mpi_my_particles
+mpi_my_particles.restype = None
+mpi_my_particles.argtypes = [ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
+mpi_gather_particlestate = _libraries['libascot.so'].mpi_gather_particlestate
+mpi_gather_particlestate.restype = None
+mpi_gather_particlestate.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(ctypes.POINTER(struct_c__SA_particle_state)), ctypes.POINTER(ctypes.c_int32), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
+mpi_gather_diag = _libraries['libascot.so'].mpi_gather_diag
+mpi_gather_diag.restype = None
+mpi_gather_diag.argtypes = [ctypes.POINTER(struct_c__SA_diag_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32]
+class struct_c__SA_plasma_1D_data(Structure):
     pass
 
-struct_plasma_1D_data._pack_ = 1 # source:False
-struct_plasma_1D_data._fields_ = [
+struct_c__SA_plasma_1D_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1D_data._fields_ = [
     ('n_rho', ctypes.c_int32),
     ('n_species', ctypes.c_int32),
     ('mass', ctypes.POINTER(ctypes.c_double)),
@@ -1847,54 +1412,89 @@ struct_plasma_1D_data._fields_ = [
     ('vtor', ctypes.POINTER(ctypes.c_double)),
 ]
 
-plasma_1D_data = struct_plasma_1D_data
-try:
-    plasma_1D_init = _libraries['libascot.so'].plasma_1D_init
-    plasma_1D_init.restype = ctypes.c_int32
-    plasma_1D_init.argtypes = [ctypes.POINTER(struct_plasma_1D_data), ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_free = _libraries['libascot.so'].plasma_1D_free
-    plasma_1D_free.restype = None
-    plasma_1D_free.argtypes = [ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_offload = _libraries['libascot.so'].plasma_1D_offload
-    plasma_1D_offload.restype = None
-    plasma_1D_offload.argtypes = [ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_eval_temp = _libraries['libascot.so'].plasma_1D_eval_temp
-    plasma_1D_eval_temp.restype = a5err
-    plasma_1D_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_eval_dens = _libraries['libascot.so'].plasma_1D_eval_dens
-    plasma_1D_eval_dens.restype = a5err
-    plasma_1D_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_eval_densandtemp = _libraries['libascot.so'].plasma_1D_eval_densandtemp
-    plasma_1D_eval_densandtemp.restype = a5err
-    plasma_1D_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1D_eval_flow = _libraries['libascot.so'].plasma_1D_eval_flow
-    plasma_1D_eval_flow.restype = a5err
-    plasma_1D_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_plasma_1D_data)]
-except AttributeError:
-    pass
-class struct_plasma_1Dt_data(Structure):
+plasma_1D_data = struct_c__SA_plasma_1D_data
+plasma_1D_init = _libraries['libascot.so'].plasma_1D_init
+plasma_1D_init.restype = ctypes.c_int32
+plasma_1D_init.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1D_data), ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+plasma_1D_free = _libraries['libascot.so'].plasma_1D_free
+plasma_1D_free.restype = None
+plasma_1D_free.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+plasma_1D_offload = _libraries['libascot.so'].plasma_1D_offload
+plasma_1D_offload.restype = None
+plasma_1D_offload.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+plasma_1D_eval_temp = _libraries['libascot.so'].plasma_1D_eval_temp
+plasma_1D_eval_temp.restype = a5err
+plasma_1D_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+plasma_1D_eval_dens = _libraries['libascot.so'].plasma_1D_eval_dens
+plasma_1D_eval_dens.restype = a5err
+plasma_1D_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+plasma_1D_eval_densandtemp = _libraries['libascot.so'].plasma_1D_eval_densandtemp
+plasma_1D_eval_densandtemp.restype = a5err
+plasma_1D_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+plasma_1D_eval_flow = _libraries['libascot.so'].plasma_1D_eval_flow
+plasma_1D_eval_flow.restype = a5err
+plasma_1D_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_plasma_1D_data)]
+class struct_c__SA_plasma_2D_data(Structure):
     pass
 
-struct_plasma_1Dt_data._pack_ = 1 # source:False
-struct_plasma_1Dt_data._fields_ = [
+class struct_c__SA_linint2D_data(Structure):
+    pass
+
+struct_c__SA_plasma_2D_data._pack_ = 1 # source:False
+struct_c__SA_plasma_2D_data._fields_ = [
+    ('n_species', ctypes.c_int32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('mass', ctypes.POINTER(ctypes.c_double)),
+    ('charge', ctypes.POINTER(ctypes.c_double)),
+    ('anum', ctypes.POINTER(ctypes.c_int32)),
+    ('znum', ctypes.POINTER(ctypes.c_int32)),
+    ('temp', ctypes.POINTER(struct_c__SA_linint2D_data)),
+    ('dens', ctypes.POINTER(struct_c__SA_linint2D_data)),
+    ('vtor', ctypes.POINTER(struct_c__SA_linint2D_data)),
+]
+
+struct_c__SA_linint2D_data._pack_ = 1 # source:False
+struct_c__SA_linint2D_data._fields_ = [
+    ('n_x', ctypes.c_int32),
+    ('n_y', ctypes.c_int32),
+    ('bc_x', ctypes.c_int32),
+    ('bc_y', ctypes.c_int32),
+    ('x_min', ctypes.c_double),
+    ('x_max', ctypes.c_double),
+    ('x_grid', ctypes.c_double),
+    ('y_min', ctypes.c_double),
+    ('y_max', ctypes.c_double),
+    ('y_grid', ctypes.c_double),
+    ('c', ctypes.POINTER(ctypes.c_double)),
+]
+
+plasma_2D_data = struct_c__SA_plasma_2D_data
+plasma_2D_init = _libraries['libascot.so'].plasma_2D_init
+plasma_2D_init.restype = ctypes.c_int32
+plasma_2D_init.argtypes = [ctypes.POINTER(struct_c__SA_plasma_2D_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, real, real, real, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+plasma_2D_free = _libraries['libascot.so'].plasma_2D_free
+plasma_2D_free.restype = None
+plasma_2D_free.argtypes = [ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+plasma_2D_offload = _libraries['libascot.so'].plasma_2D_offload
+plasma_2D_offload.restype = None
+plasma_2D_offload.argtypes = [ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+plasma_2D_eval_temp = _libraries['libascot.so'].plasma_2D_eval_temp
+plasma_2D_eval_temp.restype = a5err
+plasma_2D_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+plasma_2D_eval_dens = _libraries['libascot.so'].plasma_2D_eval_dens
+plasma_2D_eval_dens.restype = a5err
+plasma_2D_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+plasma_2D_eval_densandtemp = _libraries['libascot.so'].plasma_2D_eval_densandtemp
+plasma_2D_eval_densandtemp.restype = a5err
+plasma_2D_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+plasma_2D_eval_flow = _libraries['libascot.so'].plasma_2D_eval_flow
+plasma_2D_eval_flow.restype = a5err
+plasma_2D_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_plasma_2D_data)]
+class struct_c__SA_plasma_1Dt_data(Structure):
+    pass
+
+struct_c__SA_plasma_1Dt_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1Dt_data._fields_ = [
     ('n_rho', ctypes.c_int32),
     ('n_time', ctypes.c_int32),
     ('n_species', ctypes.c_int32),
@@ -1910,268 +1510,178 @@ struct_plasma_1Dt_data._fields_ = [
     ('vtor', ctypes.POINTER(ctypes.c_double)),
 ]
 
-plasma_1Dt_data = struct_plasma_1Dt_data
-try:
-    plasma_1Dt_init = _libraries['libascot.so'].plasma_1Dt_init
-    plasma_1Dt_init.restype = ctypes.c_int32
-    plasma_1Dt_init.argtypes = [ctypes.POINTER(struct_plasma_1Dt_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_free = _libraries['libascot.so'].plasma_1Dt_free
-    plasma_1Dt_free.restype = None
-    plasma_1Dt_free.argtypes = [ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_offload = _libraries['libascot.so'].plasma_1Dt_offload
-    plasma_1Dt_offload.restype = None
-    plasma_1Dt_offload.argtypes = [ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_eval_temp = _libraries['libascot.so'].plasma_1Dt_eval_temp
-    plasma_1Dt_eval_temp.restype = a5err
-    plasma_1Dt_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_eval_dens = _libraries['libascot.so'].plasma_1Dt_eval_dens
-    plasma_1Dt_eval_dens.restype = a5err
-    plasma_1Dt_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_eval_densandtemp = _libraries['libascot.so'].plasma_1Dt_eval_densandtemp
-    plasma_1Dt_eval_densandtemp.restype = a5err
-    plasma_1Dt_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1Dt_eval_flow = _libraries['libascot.so'].plasma_1Dt_eval_flow
-    plasma_1Dt_eval_flow.restype = a5err
-    plasma_1Dt_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_plasma_1Dt_data)]
-except AttributeError:
-    pass
-class struct_plasma_1DS_data(Structure):
+plasma_1Dt_data = struct_c__SA_plasma_1Dt_data
+plasma_1Dt_init = _libraries['libascot.so'].plasma_1Dt_init
+plasma_1Dt_init.restype = ctypes.c_int32
+plasma_1Dt_init.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1Dt_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+plasma_1Dt_free = _libraries['libascot.so'].plasma_1Dt_free
+plasma_1Dt_free.restype = None
+plasma_1Dt_free.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+plasma_1Dt_offload = _libraries['libascot.so'].plasma_1Dt_offload
+plasma_1Dt_offload.restype = None
+plasma_1Dt_offload.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+plasma_1Dt_eval_temp = _libraries['libascot.so'].plasma_1Dt_eval_temp
+plasma_1Dt_eval_temp.restype = a5err
+plasma_1Dt_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+plasma_1Dt_eval_dens = _libraries['libascot.so'].plasma_1Dt_eval_dens
+plasma_1Dt_eval_dens.restype = a5err
+plasma_1Dt_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+plasma_1Dt_eval_densandtemp = _libraries['libascot.so'].plasma_1Dt_eval_densandtemp
+plasma_1Dt_eval_densandtemp.restype = a5err
+plasma_1Dt_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+plasma_1Dt_eval_flow = _libraries['libascot.so'].plasma_1Dt_eval_flow
+plasma_1Dt_eval_flow.restype = a5err
+plasma_1Dt_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_plasma_1Dt_data)]
+class struct_c__SA_plasma_1DS_data(Structure):
     pass
 
-struct_plasma_1DS_data._pack_ = 1 # source:False
-struct_plasma_1DS_data._fields_ = [
+struct_c__SA_plasma_1DS_data._pack_ = 1 # source:False
+struct_c__SA_plasma_1DS_data._fields_ = [
     ('n_species', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('mass', ctypes.POINTER(ctypes.c_double)),
     ('charge', ctypes.POINTER(ctypes.c_double)),
     ('anum', ctypes.POINTER(ctypes.c_int32)),
     ('znum', ctypes.POINTER(ctypes.c_int32)),
-    ('temp', struct_interp1D_data * 2),
-    ('dens', ctypes.POINTER(struct_interp1D_data)),
-    ('vtor', struct_interp1D_data * 0),
+    ('temp', struct_c__SA_interp1D_data * 2),
+    ('dens', ctypes.POINTER(struct_c__SA_interp1D_data)),
+    ('vtor', struct_c__SA_interp1D_data * 0),
 ]
 
-plasma_1DS_data = struct_plasma_1DS_data
-try:
-    plasma_1DS_init = _libraries['libascot.so'].plasma_1DS_init
-    plasma_1DS_init.restype = ctypes.c_int32
-    plasma_1DS_init.argtypes = [ctypes.POINTER(struct_plasma_1DS_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_free = _libraries['libascot.so'].plasma_1DS_free
-    plasma_1DS_free.restype = None
-    plasma_1DS_free.argtypes = [ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_offload = _libraries['libascot.so'].plasma_1DS_offload
-    plasma_1DS_offload.restype = None
-    plasma_1DS_offload.argtypes = [ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_eval_temp = _libraries['libascot.so'].plasma_1DS_eval_temp
-    plasma_1DS_eval_temp.restype = a5err
-    plasma_1DS_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_eval_dens = _libraries['libascot.so'].plasma_1DS_eval_dens
-    plasma_1DS_eval_dens.restype = a5err
-    plasma_1DS_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_eval_densandtemp = _libraries['libascot.so'].plasma_1DS_eval_densandtemp
-    plasma_1DS_eval_densandtemp.restype = a5err
-    plasma_1DS_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
-try:
-    plasma_1DS_eval_flow = _libraries['libascot.so'].plasma_1DS_eval_flow
-    plasma_1DS_eval_flow.restype = a5err
-    plasma_1DS_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_plasma_1DS_data)]
-except AttributeError:
-    pass
+plasma_1DS_data = struct_c__SA_plasma_1DS_data
+plasma_1DS_init = _libraries['libascot.so'].plasma_1DS_init
+plasma_1DS_init.restype = ctypes.c_int32
+plasma_1DS_init.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1DS_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+plasma_1DS_free = _libraries['libascot.so'].plasma_1DS_free
+plasma_1DS_free.restype = None
+plasma_1DS_free.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
+plasma_1DS_offload = _libraries['libascot.so'].plasma_1DS_offload
+plasma_1DS_offload.restype = None
+plasma_1DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
+plasma_1DS_eval_temp = _libraries['libascot.so'].plasma_1DS_eval_temp
+plasma_1DS_eval_temp.restype = a5err
+plasma_1DS_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
+plasma_1DS_eval_dens = _libraries['libascot.so'].plasma_1DS_eval_dens
+plasma_1DS_eval_dens.restype = a5err
+plasma_1DS_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
+plasma_1DS_eval_densandtemp = _libraries['libascot.so'].plasma_1DS_eval_densandtemp
+plasma_1DS_eval_densandtemp.restype = a5err
+plasma_1DS_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
+plasma_1DS_eval_flow = _libraries['libascot.so'].plasma_1DS_eval_flow
+plasma_1DS_eval_flow.restype = a5err
+plasma_1DS_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_plasma_1DS_data)]
 
 # values for enumeration 'plasma_type'
 plasma_type__enumvalues = {
     0: 'plasma_type_1D',
-    1: 'plasma_type_1Dt',
-    2: 'plasma_type_1DS',
+    1: 'plasma_type_2D',
+    2: 'plasma_type_1Dt',
+    3: 'plasma_type_1DS',
 }
 plasma_type_1D = 0
-plasma_type_1Dt = 1
-plasma_type_1DS = 2
+plasma_type_2D = 1
+plasma_type_1Dt = 2
+plasma_type_1DS = 3
 plasma_type = ctypes.c_uint32 # enum
-class struct_plasma_data(Structure):
+class struct_c__SA_plasma_data(Structure):
     pass
 
-struct_plasma_data._pack_ = 1 # source:False
-struct_plasma_data._fields_ = [
+struct_c__SA_plasma_data._pack_ = 1 # source:False
+struct_c__SA_plasma_data._fields_ = [
     ('type', plasma_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('plasma_1D', plasma_1D_data),
+    ('plasma_2D', plasma_2D_data),
     ('plasma_1Dt', plasma_1Dt_data),
     ('plasma_1DS', plasma_1DS_data),
 ]
 
-plasma_data = struct_plasma_data
-try:
-    plasma_free = _libraries['libascot.so'].plasma_free
-    plasma_free.restype = None
-    plasma_free.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_offload = _libraries['libascot.so'].plasma_offload
-    plasma_offload.restype = None
-    plasma_offload.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_eval_temp = _libraries['libascot.so'].plasma_eval_temp
-    plasma_eval_temp.restype = a5err
-    plasma_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_eval_dens = _libraries['libascot.so'].plasma_eval_dens
-    plasma_eval_dens.restype = a5err
-    plasma_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_eval_densandtemp = _libraries['libascot.so'].plasma_eval_densandtemp
-    plasma_eval_densandtemp.restype = a5err
-    plasma_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_eval_flow = _libraries['libascot.so'].plasma_eval_flow
-    plasma_eval_flow.restype = a5err
-    plasma_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_get_n_species = _libraries['libascot.so'].plasma_get_n_species
-    plasma_get_n_species.restype = ctypes.c_int32
-    plasma_get_n_species.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_get_species_mass = _libraries['libascot.so'].plasma_get_species_mass
-    plasma_get_species_mass.restype = ctypes.POINTER(ctypes.c_double)
-    plasma_get_species_mass.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_get_species_charge = _libraries['libascot.so'].plasma_get_species_charge
-    plasma_get_species_charge.restype = ctypes.POINTER(ctypes.c_double)
-    plasma_get_species_charge.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_get_species_znum = _libraries['libascot.so'].plasma_get_species_znum
-    plasma_get_species_znum.restype = ctypes.POINTER(ctypes.c_int32)
-    plasma_get_species_znum.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-try:
-    plasma_get_species_anum = _libraries['libascot.so'].plasma_get_species_anum
-    plasma_get_species_anum.restype = ctypes.POINTER(ctypes.c_int32)
-    plasma_get_species_anum.argtypes = [ctypes.POINTER(struct_plasma_data)]
-except AttributeError:
-    pass
-class struct_N0_1D_data(Structure):
+plasma_data = struct_c__SA_plasma_data
+plasma_free = _libraries['libascot.so'].plasma_free
+plasma_free.restype = None
+plasma_free.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_offload = _libraries['libascot.so'].plasma_offload
+plasma_offload.restype = None
+plasma_offload.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_eval_temp = _libraries['libascot.so'].plasma_eval_temp
+plasma_eval_temp.restype = a5err
+plasma_eval_temp.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_eval_dens = _libraries['libascot.so'].plasma_eval_dens
+plasma_eval_dens.restype = a5err
+plasma_eval_dens.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_eval_densandtemp = _libraries['libascot.so'].plasma_eval_densandtemp
+plasma_eval_densandtemp.restype = a5err
+plasma_eval_densandtemp.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_eval_flow = _libraries['libascot.so'].plasma_eval_flow
+plasma_eval_flow.restype = a5err
+plasma_eval_flow.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_get_n_species = _libraries['libascot.so'].plasma_get_n_species
+plasma_get_n_species.restype = ctypes.c_int32
+plasma_get_n_species.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_get_species_mass = _libraries['libascot.so'].plasma_get_species_mass
+plasma_get_species_mass.restype = ctypes.POINTER(ctypes.c_double)
+plasma_get_species_mass.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_get_species_charge = _libraries['libascot.so'].plasma_get_species_charge
+plasma_get_species_charge.restype = ctypes.POINTER(ctypes.c_double)
+plasma_get_species_charge.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_get_species_znum = _libraries['libascot.so'].plasma_get_species_znum
+plasma_get_species_znum.restype = ctypes.POINTER(ctypes.c_int32)
+plasma_get_species_znum.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+plasma_get_species_anum = _libraries['libascot.so'].plasma_get_species_anum
+plasma_get_species_anum.restype = ctypes.POINTER(ctypes.c_int32)
+plasma_get_species_anum.argtypes = [ctypes.POINTER(struct_c__SA_plasma_data)]
+class struct_c__SA_N0_1D_data(Structure):
     pass
 
-struct_N0_1D_data._pack_ = 1 # source:False
-struct_N0_1D_data._fields_ = [
+struct_c__SA_N0_1D_data._pack_ = 1 # source:False
+struct_c__SA_N0_1D_data._fields_ = [
     ('n_species', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('anum', ctypes.POINTER(ctypes.c_int32)),
     ('znum', ctypes.POINTER(ctypes.c_int32)),
     ('maxwellian', ctypes.POINTER(ctypes.c_int32)),
-    ('n0', ctypes.POINTER(struct_linint1D_data)),
-    ('t0', ctypes.POINTER(struct_linint1D_data)),
+    ('n0', ctypes.POINTER(struct_c__SA_linint1D_data)),
+    ('t0', ctypes.POINTER(struct_c__SA_linint1D_data)),
 ]
 
-N0_1D_data = struct_N0_1D_data
-try:
-    N0_1D_init = _libraries['libascot.so'].N0_1D_init
-    N0_1D_init.restype = ctypes.c_int32
-    N0_1D_init.argtypes = [ctypes.POINTER(struct_N0_1D_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    N0_1D_free = _libraries['libascot.so'].N0_1D_free
-    N0_1D_free.restype = None
-    N0_1D_free.argtypes = [ctypes.POINTER(struct_N0_1D_data)]
-except AttributeError:
-    pass
-try:
-    N0_1D_offload = _libraries['libascot.so'].N0_1D_offload
-    N0_1D_offload.restype = None
-    N0_1D_offload.argtypes = [ctypes.POINTER(struct_N0_1D_data)]
-except AttributeError:
-    pass
-try:
-    N0_1D_eval_n0 = _libraries['libascot.so'].N0_1D_eval_n0
-    N0_1D_eval_n0.restype = a5err
-    N0_1D_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_N0_1D_data)]
-except AttributeError:
-    pass
-try:
-    N0_1D_eval_t0 = _libraries['libascot.so'].N0_1D_eval_t0
-    N0_1D_eval_t0.restype = a5err
-    N0_1D_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_N0_1D_data)]
-except AttributeError:
-    pass
-try:
-    N0_1D_get_n_species = _libraries['libascot.so'].N0_1D_get_n_species
-    N0_1D_get_n_species.restype = ctypes.c_int32
-    N0_1D_get_n_species.argtypes = [ctypes.POINTER(struct_N0_1D_data)]
-except AttributeError:
-    pass
-class struct_N0_3D_data(Structure):
+N0_1D_data = struct_c__SA_N0_1D_data
+N0_1D_init = _libraries['libascot.so'].N0_1D_init
+N0_1D_init.restype = ctypes.c_int32
+N0_1D_init.argtypes = [ctypes.POINTER(struct_c__SA_N0_1D_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+N0_1D_free = _libraries['libascot.so'].N0_1D_free
+N0_1D_free.restype = None
+N0_1D_free.argtypes = [ctypes.POINTER(struct_c__SA_N0_1D_data)]
+N0_1D_offload = _libraries['libascot.so'].N0_1D_offload
+N0_1D_offload.restype = None
+N0_1D_offload.argtypes = [ctypes.POINTER(struct_c__SA_N0_1D_data)]
+N0_1D_eval_n0 = _libraries['libascot.so'].N0_1D_eval_n0
+N0_1D_eval_n0.restype = a5err
+N0_1D_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_c__SA_N0_1D_data)]
+N0_1D_eval_t0 = _libraries['libascot.so'].N0_1D_eval_t0
+N0_1D_eval_t0.restype = a5err
+N0_1D_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, ctypes.POINTER(struct_c__SA_N0_1D_data)]
+N0_1D_get_n_species = _libraries['libascot.so'].N0_1D_get_n_species
+N0_1D_get_n_species.restype = ctypes.c_int32
+N0_1D_get_n_species.argtypes = [ctypes.POINTER(struct_c__SA_N0_1D_data)]
+class struct_c__SA_N0_3D_data(Structure):
     pass
 
-class struct_linint3D_data(Structure):
+class struct_c__SA_linint3D_data(Structure):
     pass
 
-struct_N0_3D_data._pack_ = 1 # source:False
-struct_N0_3D_data._fields_ = [
+struct_c__SA_N0_3D_data._pack_ = 1 # source:False
+struct_c__SA_N0_3D_data._fields_ = [
     ('n_species', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('anum', ctypes.POINTER(ctypes.c_int32)),
     ('znum', ctypes.POINTER(ctypes.c_int32)),
     ('maxwellian', ctypes.POINTER(ctypes.c_int32)),
-    ('n0', ctypes.POINTER(struct_linint3D_data)),
-    ('t0', ctypes.POINTER(struct_linint3D_data)),
+    ('n0', ctypes.POINTER(struct_c__SA_linint3D_data)),
+    ('t0', ctypes.POINTER(struct_c__SA_linint3D_data)),
 ]
 
-struct_linint3D_data._pack_ = 1 # source:False
-struct_linint3D_data._fields_ = [
+struct_c__SA_linint3D_data._pack_ = 1 # source:False
+struct_c__SA_linint3D_data._fields_ = [
     ('n_x', ctypes.c_int32),
     ('n_y', ctypes.c_int32),
     ('n_z', ctypes.c_int32),
@@ -2190,43 +1700,25 @@ struct_linint3D_data._fields_ = [
     ('c', ctypes.POINTER(ctypes.c_double)),
 ]
 
-N0_3D_data = struct_N0_3D_data
-try:
-    N0_3D_init = _libraries['libascot.so'].N0_3D_init
-    N0_3D_init.restype = ctypes.c_int32
-    N0_3D_init.argtypes = [ctypes.POINTER(struct_N0_3D_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    N0_3D_free = _libraries['libascot.so'].N0_3D_free
-    N0_3D_free.restype = None
-    N0_3D_free.argtypes = [ctypes.POINTER(struct_N0_3D_data)]
-except AttributeError:
-    pass
-try:
-    N0_3D_offload = _libraries['libascot.so'].N0_3D_offload
-    N0_3D_offload.restype = None
-    N0_3D_offload.argtypes = [ctypes.POINTER(struct_N0_3D_data)]
-except AttributeError:
-    pass
-try:
-    N0_3D_eval_n0 = _libraries['libascot.so'].N0_3D_eval_n0
-    N0_3D_eval_n0.restype = a5err
-    N0_3D_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_N0_3D_data)]
-except AttributeError:
-    pass
-try:
-    N0_3D_eval_t0 = _libraries['libascot.so'].N0_3D_eval_t0
-    N0_3D_eval_t0.restype = a5err
-    N0_3D_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_N0_3D_data)]
-except AttributeError:
-    pass
-try:
-    N0_3D_get_n_species = _libraries['libascot.so'].N0_3D_get_n_species
-    N0_3D_get_n_species.restype = ctypes.c_int32
-    N0_3D_get_n_species.argtypes = [ctypes.POINTER(struct_N0_3D_data)]
-except AttributeError:
-    pass
+N0_3D_data = struct_c__SA_N0_3D_data
+N0_3D_init = _libraries['libascot.so'].N0_3D_init
+N0_3D_init.restype = ctypes.c_int32
+N0_3D_init.argtypes = [ctypes.POINTER(struct_c__SA_N0_3D_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+N0_3D_free = _libraries['libascot.so'].N0_3D_free
+N0_3D_free.restype = None
+N0_3D_free.argtypes = [ctypes.POINTER(struct_c__SA_N0_3D_data)]
+N0_3D_offload = _libraries['libascot.so'].N0_3D_offload
+N0_3D_offload.restype = None
+N0_3D_offload.argtypes = [ctypes.POINTER(struct_c__SA_N0_3D_data)]
+N0_3D_eval_n0 = _libraries['libascot.so'].N0_3D_eval_n0
+N0_3D_eval_n0.restype = a5err
+N0_3D_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_N0_3D_data)]
+N0_3D_eval_t0 = _libraries['libascot.so'].N0_3D_eval_t0
+N0_3D_eval_t0.restype = a5err
+N0_3D_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, ctypes.POINTER(struct_c__SA_N0_3D_data)]
+N0_3D_get_n_species = _libraries['libascot.so'].N0_3D_get_n_species
+N0_3D_get_n_species.restype = ctypes.c_int32
+N0_3D_get_n_species.argtypes = [ctypes.POINTER(struct_c__SA_N0_3D_data)]
 
 # values for enumeration 'neutral_type'
 neutral_type__enumvalues = {
@@ -2236,53 +1728,38 @@ neutral_type__enumvalues = {
 neutral_type_1D = 0
 neutral_type_3D = 1
 neutral_type = ctypes.c_uint32 # enum
-class struct_neutral_data(Structure):
+class struct_c__SA_neutral_data(Structure):
     pass
 
-struct_neutral_data._pack_ = 1 # source:False
-struct_neutral_data._fields_ = [
+struct_c__SA_neutral_data._pack_ = 1 # source:False
+struct_c__SA_neutral_data._fields_ = [
     ('type', neutral_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('N01D', N0_1D_data),
     ('N03D', N0_3D_data),
 ]
 
-neutral_data = struct_neutral_data
-try:
-    neutral_free = _libraries['libascot.so'].neutral_free
-    neutral_free.restype = None
-    neutral_free.argtypes = [ctypes.POINTER(struct_neutral_data)]
-except AttributeError:
-    pass
-try:
-    neutral_offload = _libraries['libascot.so'].neutral_offload
-    neutral_offload.restype = None
-    neutral_offload.argtypes = [ctypes.POINTER(struct_neutral_data)]
-except AttributeError:
-    pass
-try:
-    neutral_eval_n0 = _libraries['libascot.so'].neutral_eval_n0
-    neutral_eval_n0.restype = a5err
-    neutral_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_neutral_data)]
-except AttributeError:
-    pass
-try:
-    neutral_eval_t0 = _libraries['libascot.so'].neutral_eval_t0
-    neutral_eval_t0.restype = a5err
-    neutral_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_neutral_data)]
-except AttributeError:
-    pass
-try:
-    neutral_get_n_species = _libraries['libascot.so'].neutral_get_n_species
-    neutral_get_n_species.restype = ctypes.c_int32
-    neutral_get_n_species.argtypes = [ctypes.POINTER(struct_neutral_data)]
-except AttributeError:
-    pass
-class struct_wall_2d_data(Structure):
+neutral_data = struct_c__SA_neutral_data
+neutral_free = _libraries['libascot.so'].neutral_free
+neutral_free.restype = None
+neutral_free.argtypes = [ctypes.POINTER(struct_c__SA_neutral_data)]
+neutral_offload = _libraries['libascot.so'].neutral_offload
+neutral_offload.restype = None
+neutral_offload.argtypes = [ctypes.POINTER(struct_c__SA_neutral_data)]
+neutral_eval_n0 = _libraries['libascot.so'].neutral_eval_n0
+neutral_eval_n0.restype = a5err
+neutral_eval_n0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_c__SA_neutral_data)]
+neutral_eval_t0 = _libraries['libascot.so'].neutral_eval_t0
+neutral_eval_t0.restype = a5err
+neutral_eval_t0.argtypes = [ctypes.POINTER(ctypes.c_double), real, real, real, real, real, ctypes.POINTER(struct_c__SA_neutral_data)]
+neutral_get_n_species = _libraries['libascot.so'].neutral_get_n_species
+neutral_get_n_species.restype = ctypes.c_int32
+neutral_get_n_species.argtypes = [ctypes.POINTER(struct_c__SA_neutral_data)]
+class struct_c__SA_wall_2d_data(Structure):
     pass
 
-struct_wall_2d_data._pack_ = 1 # source:False
-struct_wall_2d_data._fields_ = [
+struct_c__SA_wall_2d_data._pack_ = 1 # source:False
+struct_c__SA_wall_2d_data._fields_ = [
     ('n', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('wall_r', ctypes.POINTER(ctypes.c_double)),
@@ -2290,48 +1767,30 @@ struct_wall_2d_data._fields_ = [
     ('flag', ctypes.POINTER(ctypes.c_int32)),
 ]
 
-wall_2d_data = struct_wall_2d_data
-try:
-    wall_2d_init = _libraries['libascot.so'].wall_2d_init
-    wall_2d_init.restype = ctypes.c_int32
-    wall_2d_init.argtypes = [ctypes.POINTER(struct_wall_2d_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    wall_2d_free = _libraries['libascot.so'].wall_2d_free
-    wall_2d_free.restype = None
-    wall_2d_free.argtypes = [ctypes.POINTER(struct_wall_2d_data)]
-except AttributeError:
-    pass
-try:
-    wall_2d_offload = _libraries['libascot.so'].wall_2d_offload
-    wall_2d_offload.restype = None
-    wall_2d_offload.argtypes = [ctypes.POINTER(struct_wall_2d_data)]
-except AttributeError:
-    pass
-try:
-    wall_2d_inside = _libraries['libascot.so'].wall_2d_inside
-    wall_2d_inside.restype = ctypes.c_int32
-    wall_2d_inside.argtypes = [real, real, ctypes.POINTER(struct_wall_2d_data)]
-except AttributeError:
-    pass
-try:
-    wall_2d_hit_wall = _libraries['libascot.so'].wall_2d_hit_wall
-    wall_2d_hit_wall.restype = ctypes.c_int32
-    wall_2d_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_wall_2d_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    wall_2d_find_intersection = _libraries['libascot.so'].wall_2d_find_intersection
-    wall_2d_find_intersection.restype = ctypes.c_int32
-    wall_2d_find_intersection.argtypes = [real, real, real, real, ctypes.POINTER(struct_wall_2d_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-class struct_wall_3d_data(Structure):
+wall_2d_data = struct_c__SA_wall_2d_data
+wall_2d_init = _libraries['libascot.so'].wall_2d_init
+wall_2d_init.restype = ctypes.c_int32
+wall_2d_init.argtypes = [ctypes.POINTER(struct_c__SA_wall_2d_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32)]
+wall_2d_free = _libraries['libascot.so'].wall_2d_free
+wall_2d_free.restype = None
+wall_2d_free.argtypes = [ctypes.POINTER(struct_c__SA_wall_2d_data)]
+wall_2d_offload = _libraries['libascot.so'].wall_2d_offload
+wall_2d_offload.restype = None
+wall_2d_offload.argtypes = [ctypes.POINTER(struct_c__SA_wall_2d_data)]
+wall_2d_inside = _libraries['libascot.so'].wall_2d_inside
+wall_2d_inside.restype = ctypes.c_int32
+wall_2d_inside.argtypes = [real, real, ctypes.POINTER(struct_c__SA_wall_2d_data)]
+wall_2d_hit_wall = _libraries['libascot.so'].wall_2d_hit_wall
+wall_2d_hit_wall.restype = ctypes.c_int32
+wall_2d_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_c__SA_wall_2d_data), ctypes.POINTER(ctypes.c_double)]
+wall_2d_find_intersection = _libraries['libascot.so'].wall_2d_find_intersection
+wall_2d_find_intersection.restype = ctypes.c_int32
+wall_2d_find_intersection.argtypes = [real, real, real, real, ctypes.POINTER(struct_c__SA_wall_2d_data), ctypes.POINTER(ctypes.c_double)]
+class struct_c__SA_wall_3d_data(Structure):
     pass
 
-struct_wall_3d_data._pack_ = 1 # source:False
-struct_wall_3d_data._fields_ = [
+struct_c__SA_wall_3d_data._pack_ = 1 # source:False
+struct_c__SA_wall_3d_data._fields_ = [
     ('n', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('xmin', ctypes.c_double),
@@ -2352,61 +1811,34 @@ struct_wall_3d_data._fields_ = [
     ('PADDING_1', ctypes.c_ubyte * 4),
 ]
 
-wall_3d_data = struct_wall_3d_data
-try:
-    wall_3d_init = _libraries['libascot.so'].wall_3d_init
-    wall_3d_init.restype = ctypes.c_int32
-    wall_3d_init.argtypes = [ctypes.POINTER(struct_wall_3d_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    wall_3d_free = _libraries['libascot.so'].wall_3d_free
-    wall_3d_free.restype = None
-    wall_3d_free.argtypes = [ctypes.POINTER(struct_wall_3d_data)]
-except AttributeError:
-    pass
-try:
-    wall_3d_offload = _libraries['libascot.so'].wall_3d_offload
-    wall_3d_offload.restype = None
-    wall_3d_offload.argtypes = [ctypes.POINTER(struct_wall_3d_data)]
-except AttributeError:
-    pass
-try:
-    wall_3d_hit_wall = _libraries['libascot.so'].wall_3d_hit_wall
-    wall_3d_hit_wall.restype = ctypes.c_int32
-    wall_3d_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    wall_3d_hit_wall_full = _libraries['libascot.so'].wall_3d_hit_wall_full
-    wall_3d_hit_wall_full.restype = ctypes.c_int32
-    wall_3d_hit_wall_full.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    wall_3d_tri_collision = _libraries['libascot.so'].wall_3d_tri_collision
-    wall_3d_tri_collision.restype = ctypes.c_double
-    wall_3d_tri_collision.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
-except AttributeError:
-    pass
-try:
-    wall_3d_init_tree = _libraries['libascot.so'].wall_3d_init_tree
-    wall_3d_init_tree.restype = None
-    wall_3d_init_tree.argtypes = [ctypes.POINTER(struct_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    wall_3d_tri_in_cube = _libraries['libascot.so'].wall_3d_tri_in_cube
-    wall_3d_tri_in_cube.restype = ctypes.c_int32
-    wall_3d_tri_in_cube.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
-except AttributeError:
-    pass
-try:
-    wall_3d_quad_collision = _libraries['libascot.so'].wall_3d_quad_collision
-    wall_3d_quad_collision.restype = ctypes.c_int32
-    wall_3d_quad_collision.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
-except AttributeError:
-    pass
+wall_3d_data = struct_c__SA_wall_3d_data
+wall_3d_init = _libraries['libascot.so'].wall_3d_init
+wall_3d_init.restype = ctypes.c_int32
+wall_3d_init.argtypes = [ctypes.POINTER(struct_c__SA_wall_3d_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32)]
+wall_3d_free = _libraries['libascot.so'].wall_3d_free
+wall_3d_free.restype = None
+wall_3d_free.argtypes = [ctypes.POINTER(struct_c__SA_wall_3d_data)]
+wall_3d_offload = _libraries['libascot.so'].wall_3d_offload
+wall_3d_offload.restype = None
+wall_3d_offload.argtypes = [ctypes.POINTER(struct_c__SA_wall_3d_data)]
+wall_3d_hit_wall = _libraries['libascot.so'].wall_3d_hit_wall
+wall_3d_hit_wall.restype = ctypes.c_int32
+wall_3d_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_c__SA_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
+wall_3d_hit_wall_full = _libraries['libascot.so'].wall_3d_hit_wall_full
+wall_3d_hit_wall_full.restype = ctypes.c_int32
+wall_3d_hit_wall_full.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_c__SA_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
+wall_3d_tri_collision = _libraries['libascot.so'].wall_3d_tri_collision
+wall_3d_tri_collision.restype = ctypes.c_double
+wall_3d_tri_collision.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
+wall_3d_init_tree = _libraries['libascot.so'].wall_3d_init_tree
+wall_3d_init_tree.restype = None
+wall_3d_init_tree.argtypes = [ctypes.POINTER(struct_c__SA_wall_3d_data), ctypes.POINTER(ctypes.c_double)]
+wall_3d_tri_in_cube = _libraries['libascot.so'].wall_3d_tri_in_cube
+wall_3d_tri_in_cube.restype = ctypes.c_int32
+wall_3d_tri_in_cube.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
+wall_3d_quad_collision = _libraries['libascot.so'].wall_3d_quad_collision
+wall_3d_quad_collision.restype = ctypes.c_int32
+wall_3d_quad_collision.argtypes = [ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3, ctypes.c_double * 3]
 
 # values for enumeration 'wall_type'
 wall_type__enumvalues = {
@@ -2416,93 +1848,66 @@ wall_type__enumvalues = {
 wall_type_2D = 0
 wall_type_3D = 1
 wall_type = ctypes.c_uint32 # enum
-class struct_wall_data(Structure):
+class struct_c__SA_wall_data(Structure):
     pass
 
-struct_wall_data._pack_ = 1 # source:False
-struct_wall_data._fields_ = [
+struct_c__SA_wall_data._pack_ = 1 # source:False
+struct_c__SA_wall_data._fields_ = [
     ('type', wall_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('w2d', wall_2d_data),
     ('w3d', wall_3d_data),
 ]
 
-wall_data = struct_wall_data
-try:
-    wall_free = _libraries['libascot.so'].wall_free
-    wall_free.restype = None
-    wall_free.argtypes = [ctypes.POINTER(struct_wall_data)]
-except AttributeError:
-    pass
-try:
-    wall_offload = _libraries['libascot.so'].wall_offload
-    wall_offload.restype = None
-    wall_offload.argtypes = [ctypes.POINTER(struct_wall_data)]
-except AttributeError:
-    pass
-try:
-    wall_hit_wall = _libraries['libascot.so'].wall_hit_wall
-    wall_hit_wall.restype = ctypes.c_int32
-    wall_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_wall_data), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    wall_get_n_elements = _libraries['libascot.so'].wall_get_n_elements
-    wall_get_n_elements.restype = ctypes.c_int32
-    wall_get_n_elements.argtypes = [ctypes.POINTER(struct_wall_data)]
-except AttributeError:
-    pass
-try:
-    wall_get_flag = _libraries['libascot.so'].wall_get_flag
-    wall_get_flag.restype = ctypes.c_int32
-    wall_get_flag.argtypes = [ctypes.POINTER(struct_wall_data), ctypes.c_int32]
-except AttributeError:
-    pass
-class struct_boozer_data(Structure):
+wall_data = struct_c__SA_wall_data
+wall_free = _libraries['libascot.so'].wall_free
+wall_free.restype = None
+wall_free.argtypes = [ctypes.POINTER(struct_c__SA_wall_data)]
+wall_offload = _libraries['libascot.so'].wall_offload
+wall_offload.restype = None
+wall_offload.argtypes = [ctypes.POINTER(struct_c__SA_wall_data)]
+wall_hit_wall = _libraries['libascot.so'].wall_hit_wall
+wall_hit_wall.restype = ctypes.c_int32
+wall_hit_wall.argtypes = [real, real, real, real, real, real, ctypes.POINTER(struct_c__SA_wall_data), ctypes.POINTER(ctypes.c_double)]
+wall_get_n_elements = _libraries['libascot.so'].wall_get_n_elements
+wall_get_n_elements.restype = ctypes.c_int32
+wall_get_n_elements.argtypes = [ctypes.POINTER(struct_c__SA_wall_data)]
+wall_get_flag = _libraries['libascot.so'].wall_get_flag
+wall_get_flag.restype = ctypes.c_int32
+wall_get_flag.argtypes = [ctypes.POINTER(struct_c__SA_wall_data), ctypes.c_int32]
+class struct_c__SA_boozer_data(Structure):
     pass
 
-struct_boozer_data._pack_ = 1 # source:False
-struct_boozer_data._fields_ = [
+struct_c__SA_boozer_data._pack_ = 1 # source:False
+struct_c__SA_boozer_data._fields_ = [
     ('psi_min', ctypes.c_double),
     ('psi_max', ctypes.c_double),
     ('rs', ctypes.POINTER(ctypes.c_double)),
     ('zs', ctypes.POINTER(ctypes.c_double)),
     ('nrzs', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
-    ('nu_psitheta', struct_interp2D_data),
-    ('theta_psithetageom', struct_interp2D_data),
+    ('nu_psitheta', struct_c__SA_interp2D_data),
+    ('theta_psithetageom', struct_c__SA_interp2D_data),
 ]
 
-boozer_data = struct_boozer_data
-try:
-    boozer_init = _libraries['libascot.so'].boozer_init
-    boozer_init.restype = ctypes.c_int32
-    boozer_init.argtypes = [ctypes.POINTER(struct_boozer_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    boozer_free = _libraries['libascot.so'].boozer_free
-    boozer_free.restype = None
-    boozer_free.argtypes = [ctypes.POINTER(struct_boozer_data)]
-except AttributeError:
-    pass
-try:
-    boozer_offload = _libraries['libascot.so'].boozer_offload
-    boozer_offload.restype = None
-    boozer_offload.argtypes = [ctypes.POINTER(struct_boozer_data)]
-except AttributeError:
-    pass
-try:
-    boozer_eval_psithetazeta = _libraries['libascot.so'].boozer_eval_psithetazeta
-    boozer_eval_psithetazeta.restype = a5err
-    boozer_eval_psithetazeta.argtypes = [ctypes.c_double * 12, ctypes.POINTER(ctypes.c_int32), real, real, real, ctypes.POINTER(struct_B_field_data), ctypes.POINTER(struct_boozer_data)]
-except AttributeError:
-    pass
-class struct_mhd_stat_data(Structure):
+boozer_data = struct_c__SA_boozer_data
+boozer_init = _libraries['libascot.so'].boozer_init
+boozer_init.restype = ctypes.c_int32
+boozer_init.argtypes = [ctypes.POINTER(struct_c__SA_boozer_data), ctypes.c_int32, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+boozer_free = _libraries['libascot.so'].boozer_free
+boozer_free.restype = None
+boozer_free.argtypes = [ctypes.POINTER(struct_c__SA_boozer_data)]
+boozer_offload = _libraries['libascot.so'].boozer_offload
+boozer_offload.restype = None
+boozer_offload.argtypes = [ctypes.POINTER(struct_c__SA_boozer_data)]
+boozer_eval_psithetazeta = _libraries['libascot.so'].boozer_eval_psithetazeta
+boozer_eval_psithetazeta.restype = a5err
+boozer_eval_psithetazeta.argtypes = [ctypes.c_double * 12, ctypes.POINTER(ctypes.c_int32), real, real, real, ctypes.POINTER(struct_c__SA_B_field_data), ctypes.POINTER(struct_c__SA_boozer_data)]
+class struct_c__SA_mhd_stat_data(Structure):
     pass
 
-struct_mhd_stat_data._pack_ = 1 # source:False
-struct_mhd_stat_data._fields_ = [
+struct_c__SA_mhd_stat_data._pack_ = 1 # source:False
+struct_c__SA_mhd_stat_data._fields_ = [
     ('n_modes', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('rho_min', ctypes.c_double),
@@ -2512,46 +1917,31 @@ struct_mhd_stat_data._fields_ = [
     ('amplitude_nm', ctypes.POINTER(ctypes.c_double)),
     ('omega_nm', ctypes.POINTER(ctypes.c_double)),
     ('phase_nm', ctypes.POINTER(ctypes.c_double)),
-    ('alpha_nm', ctypes.POINTER(struct_interp1D_data)),
-    ('phi_nm', ctypes.POINTER(struct_interp1D_data)),
+    ('alpha_nm', ctypes.POINTER(struct_c__SA_interp1D_data)),
+    ('phi_nm', ctypes.POINTER(struct_c__SA_interp1D_data)),
 ]
 
-mhd_stat_data = struct_mhd_stat_data
-try:
-    mhd_stat_init = _libraries['libascot.so'].mhd_stat_init
-    mhd_stat_init.restype = ctypes.c_int32
-    mhd_stat_init.argtypes = [ctypes.POINTER(struct_mhd_stat_data), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    mhd_stat_free = _libraries['libascot.so'].mhd_stat_free
-    mhd_stat_free.restype = None
-    mhd_stat_free.argtypes = [ctypes.POINTER(struct_mhd_stat_data)]
-except AttributeError:
-    pass
-try:
-    mhd_stat_offload = _libraries['libascot.so'].mhd_stat_offload
-    mhd_stat_offload.restype = None
-    mhd_stat_offload.argtypes = [ctypes.POINTER(struct_mhd_stat_data)]
-except AttributeError:
-    pass
-try:
-    mhd_stat_eval = _libraries['libascot.so'].mhd_stat_eval
-    mhd_stat_eval.restype = a5err
-    mhd_stat_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_stat_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    mhd_stat_perturbations = _libraries['libascot.so'].mhd_stat_perturbations
-    mhd_stat_perturbations.restype = a5err
-    mhd_stat_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_stat_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-class struct_mhd_nonstat_data(Structure):
+mhd_stat_data = struct_c__SA_mhd_stat_data
+mhd_stat_init = _libraries['libascot.so'].mhd_stat_init
+mhd_stat_init.restype = ctypes.c_int32
+mhd_stat_init.argtypes = [ctypes.POINTER(struct_c__SA_mhd_stat_data), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+mhd_stat_free = _libraries['libascot.so'].mhd_stat_free
+mhd_stat_free.restype = None
+mhd_stat_free.argtypes = [ctypes.POINTER(struct_c__SA_mhd_stat_data)]
+mhd_stat_offload = _libraries['libascot.so'].mhd_stat_offload
+mhd_stat_offload.restype = None
+mhd_stat_offload.argtypes = [ctypes.POINTER(struct_c__SA_mhd_stat_data)]
+mhd_stat_eval = _libraries['libascot.so'].mhd_stat_eval
+mhd_stat_eval.restype = a5err
+mhd_stat_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_stat_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+mhd_stat_perturbations = _libraries['libascot.so'].mhd_stat_perturbations
+mhd_stat_perturbations.restype = a5err
+mhd_stat_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_stat_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+class struct_c__SA_mhd_nonstat_data(Structure):
     pass
 
-struct_mhd_nonstat_data._pack_ = 1 # source:False
-struct_mhd_nonstat_data._fields_ = [
+struct_c__SA_mhd_nonstat_data._pack_ = 1 # source:False
+struct_c__SA_mhd_nonstat_data._fields_ = [
     ('n_modes', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('rho_min', ctypes.c_double),
@@ -2561,41 +1951,26 @@ struct_mhd_nonstat_data._fields_ = [
     ('amplitude_nm', ctypes.POINTER(ctypes.c_double)),
     ('omega_nm', ctypes.POINTER(ctypes.c_double)),
     ('phase_nm', ctypes.POINTER(ctypes.c_double)),
-    ('alpha_nm', ctypes.POINTER(struct_interp2D_data)),
-    ('phi_nm', ctypes.POINTER(struct_interp2D_data)),
+    ('alpha_nm', ctypes.POINTER(struct_c__SA_interp2D_data)),
+    ('phi_nm', ctypes.POINTER(struct_c__SA_interp2D_data)),
 ]
 
-mhd_nonstat_data = struct_mhd_nonstat_data
-try:
-    mhd_nonstat_init = _libraries['libascot.so'].mhd_nonstat_init
-    mhd_nonstat_init.restype = ctypes.c_int32
-    mhd_nonstat_init.argtypes = [ctypes.POINTER(struct_mhd_nonstat_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, real, real, real, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    mhd_nonstat_free = _libraries['libascot.so'].mhd_nonstat_free
-    mhd_nonstat_free.restype = None
-    mhd_nonstat_free.argtypes = [ctypes.POINTER(struct_mhd_nonstat_data)]
-except AttributeError:
-    pass
-try:
-    mhd_nonstat_offload = _libraries['libascot.so'].mhd_nonstat_offload
-    mhd_nonstat_offload.restype = None
-    mhd_nonstat_offload.argtypes = [ctypes.POINTER(struct_mhd_nonstat_data)]
-except AttributeError:
-    pass
-try:
-    mhd_nonstat_eval = _libraries['libascot.so'].mhd_nonstat_eval
-    mhd_nonstat_eval.restype = a5err
-    mhd_nonstat_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_nonstat_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    mhd_nonstat_perturbations = _libraries['libascot.so'].mhd_nonstat_perturbations
-    mhd_nonstat_perturbations.restype = a5err
-    mhd_nonstat_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_nonstat_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
+mhd_nonstat_data = struct_c__SA_mhd_nonstat_data
+mhd_nonstat_init = _libraries['libascot.so'].mhd_nonstat_init
+mhd_nonstat_init.restype = ctypes.c_int32
+mhd_nonstat_init.argtypes = [ctypes.POINTER(struct_c__SA_mhd_nonstat_data), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, real, real, real, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+mhd_nonstat_free = _libraries['libascot.so'].mhd_nonstat_free
+mhd_nonstat_free.restype = None
+mhd_nonstat_free.argtypes = [ctypes.POINTER(struct_c__SA_mhd_nonstat_data)]
+mhd_nonstat_offload = _libraries['libascot.so'].mhd_nonstat_offload
+mhd_nonstat_offload.restype = None
+mhd_nonstat_offload.argtypes = [ctypes.POINTER(struct_c__SA_mhd_nonstat_data)]
+mhd_nonstat_eval = _libraries['libascot.so'].mhd_nonstat_eval
+mhd_nonstat_eval.restype = a5err
+mhd_nonstat_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_nonstat_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+mhd_nonstat_perturbations = _libraries['libascot.so'].mhd_nonstat_perturbations
+mhd_nonstat_perturbations.restype = a5err
+mhd_nonstat_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_nonstat_data), ctypes.POINTER(struct_c__SA_B_field_data)]
 
 # values for enumeration 'mhd_type'
 mhd_type__enumvalues = {
@@ -2605,83 +1980,53 @@ mhd_type__enumvalues = {
 mhd_type_stat = 0
 mhd_type_nonstat = 1
 mhd_type = ctypes.c_uint32 # enum
-class struct_mhd_data(Structure):
+class struct_c__SA_mhd_data(Structure):
     pass
 
-struct_mhd_data._pack_ = 1 # source:False
-struct_mhd_data._fields_ = [
+struct_c__SA_mhd_data._pack_ = 1 # source:False
+struct_c__SA_mhd_data._fields_ = [
     ('type', mhd_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('stat', mhd_stat_data),
     ('nonstat', mhd_nonstat_data),
 ]
 
-mhd_data = struct_mhd_data
-try:
-    mhd_free = _libraries['libascot.so'].mhd_free
-    mhd_free.restype = None
-    mhd_free.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_offload = _libraries['libascot.so'].mhd_offload
-    mhd_offload.restype = None
-    mhd_offload.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_eval = _libraries['libascot.so'].mhd_eval
-    mhd_eval.restype = a5err
-    mhd_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    mhd_perturbations = _libraries['libascot.so'].mhd_perturbations
-    mhd_perturbations.restype = a5err
-    mhd_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_boozer_data), ctypes.POINTER(struct_mhd_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_n_modes = _libraries['libascot.so'].mhd_get_n_modes
-    mhd_get_n_modes.restype = ctypes.c_int32
-    mhd_get_n_modes.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_nmode = _libraries['libascot.so'].mhd_get_nmode
-    mhd_get_nmode.restype = ctypes.POINTER(ctypes.c_int32)
-    mhd_get_nmode.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_mmode = _libraries['libascot.so'].mhd_get_mmode
-    mhd_get_mmode.restype = ctypes.POINTER(ctypes.c_int32)
-    mhd_get_mmode.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_amplitude = _libraries['libascot.so'].mhd_get_amplitude
-    mhd_get_amplitude.restype = ctypes.POINTER(ctypes.c_double)
-    mhd_get_amplitude.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_frequency = _libraries['libascot.so'].mhd_get_frequency
-    mhd_get_frequency.restype = ctypes.POINTER(ctypes.c_double)
-    mhd_get_frequency.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-try:
-    mhd_get_phase = _libraries['libascot.so'].mhd_get_phase
-    mhd_get_phase.restype = ctypes.POINTER(ctypes.c_double)
-    mhd_get_phase.argtypes = [ctypes.POINTER(struct_mhd_data)]
-except AttributeError:
-    pass
-class struct_asigma_loc_data(Structure):
+mhd_data = struct_c__SA_mhd_data
+mhd_free = _libraries['libascot.so'].mhd_free
+mhd_free.restype = None
+mhd_free.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_offload = _libraries['libascot.so'].mhd_offload
+mhd_offload.restype = None
+mhd_offload.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_eval = _libraries['libascot.so'].mhd_eval
+mhd_eval.restype = a5err
+mhd_eval.argtypes = [ctypes.c_double * 10, real, real, real, real, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+mhd_perturbations = _libraries['libascot.so'].mhd_perturbations
+mhd_perturbations.restype = a5err
+mhd_perturbations.argtypes = [ctypes.c_double * 7, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_boozer_data), ctypes.POINTER(struct_c__SA_mhd_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+mhd_get_n_modes = _libraries['libascot.so'].mhd_get_n_modes
+mhd_get_n_modes.restype = ctypes.c_int32
+mhd_get_n_modes.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_get_nmode = _libraries['libascot.so'].mhd_get_nmode
+mhd_get_nmode.restype = ctypes.POINTER(ctypes.c_int32)
+mhd_get_nmode.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_get_mmode = _libraries['libascot.so'].mhd_get_mmode
+mhd_get_mmode.restype = ctypes.POINTER(ctypes.c_int32)
+mhd_get_mmode.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_get_amplitude = _libraries['libascot.so'].mhd_get_amplitude
+mhd_get_amplitude.restype = ctypes.POINTER(ctypes.c_double)
+mhd_get_amplitude.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_get_frequency = _libraries['libascot.so'].mhd_get_frequency
+mhd_get_frequency.restype = ctypes.POINTER(ctypes.c_double)
+mhd_get_frequency.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+mhd_get_phase = _libraries['libascot.so'].mhd_get_phase
+mhd_get_phase.restype = ctypes.POINTER(ctypes.c_double)
+mhd_get_phase.argtypes = [ctypes.POINTER(struct_c__SA_mhd_data)]
+class struct_c__SA_asigma_loc_data(Structure):
     pass
 
-struct_asigma_loc_data._pack_ = 1 # source:False
-struct_asigma_loc_data._fields_ = [
+struct_c__SA_asigma_loc_data._pack_ = 1 # source:False
+struct_c__SA_asigma_loc_data._fields_ = [
     ('N_reac', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('z_1', ctypes.POINTER(ctypes.c_int32)),
@@ -2689,54 +2034,33 @@ struct_asigma_loc_data._fields_ = [
     ('z_2', ctypes.POINTER(ctypes.c_int32)),
     ('a_2', ctypes.POINTER(ctypes.c_int32)),
     ('reac_type', ctypes.POINTER(ctypes.c_int32)),
-    ('sigma', ctypes.POINTER(struct_interp1D_data)),
-    ('sigmav', ctypes.POINTER(struct_interp2D_data)),
-    ('BMSsigmav', ctypes.POINTER(struct_interp3D_data)),
+    ('sigma', ctypes.POINTER(struct_c__SA_interp1D_data)),
+    ('sigmav', ctypes.POINTER(struct_c__SA_interp2D_data)),
+    ('BMSsigmav', ctypes.POINTER(struct_c__SA_interp3D_data)),
 ]
 
-asigma_loc_data = struct_asigma_loc_data
-try:
-    asigma_loc_init = _libraries['libascot.so'].asigma_loc_init
-    asigma_loc_init.restype = ctypes.c_int32
-    asigma_loc_init.argtypes = [ctypes.POINTER(struct_asigma_loc_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_free = _libraries['libascot.so'].asigma_loc_free
-    asigma_loc_free.restype = None
-    asigma_loc_free.argtypes = [ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_offload = _libraries['libascot.so'].asigma_loc_offload
-    asigma_loc_offload.restype = None
-    asigma_loc_offload.argtypes = [ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_eval_sigma = _libraries['libascot.so'].asigma_loc_eval_sigma
-    asigma_loc_eval_sigma.restype = a5err
-    asigma_loc_eval_sigma.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_eval_sigmav = _libraries['libascot.so'].asigma_loc_eval_sigmav
-    asigma_loc_eval_sigmav.restype = a5err
-    asigma_loc_eval_sigmav.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_eval_cx = _libraries['libascot.so'].asigma_loc_eval_cx
-    asigma_loc_eval_cx.restype = a5err
-    asigma_loc_eval_cx.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
-try:
-    asigma_loc_eval_bms = _libraries['libascot.so'].asigma_loc_eval_bms
-    asigma_loc_eval_bms.restype = a5err
-    asigma_loc_eval_bms.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(struct_asigma_loc_data)]
-except AttributeError:
-    pass
+asigma_loc_data = struct_c__SA_asigma_loc_data
+asigma_loc_init = _libraries['libascot.so'].asigma_loc_init
+asigma_loc_init.restype = ctypes.c_int32
+asigma_loc_init.argtypes = [ctypes.POINTER(struct_c__SA_asigma_loc_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+asigma_loc_free = _libraries['libascot.so'].asigma_loc_free
+asigma_loc_free.restype = None
+asigma_loc_free.argtypes = [ctypes.POINTER(struct_c__SA_asigma_loc_data)]
+asigma_loc_offload = _libraries['libascot.so'].asigma_loc_offload
+asigma_loc_offload.restype = None
+asigma_loc_offload.argtypes = [ctypes.POINTER(struct_c__SA_asigma_loc_data)]
+asigma_loc_eval_sigma = _libraries['libascot.so'].asigma_loc_eval_sigma
+asigma_loc_eval_sigma.restype = a5err
+asigma_loc_eval_sigma.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_asigma_loc_data)]
+asigma_loc_eval_sigmav = _libraries['libascot.so'].asigma_loc_eval_sigmav
+asigma_loc_eval_sigmav.restype = a5err
+asigma_loc_eval_sigmav.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, real, real, real, real, ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_asigma_loc_data)]
+asigma_loc_eval_cx = _libraries['libascot.so'].asigma_loc_eval_cx
+asigma_loc_eval_cx.restype = a5err
+asigma_loc_eval_cx.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(struct_c__SA_asigma_loc_data)]
+asigma_loc_eval_bms = _libraries['libascot.so'].asigma_loc_eval_bms
+asigma_loc_eval_bms.restype = a5err
+asigma_loc_eval_bms.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(struct_c__SA_asigma_loc_data)]
 
 # values for enumeration 'asigma_type'
 asigma_type__enumvalues = {
@@ -2769,64 +2093,43 @@ sigmaveff_ioniz = 8
 sigmaveff_recomb = 9
 sigmaveff_CX = 10
 asigma_reac_type = ctypes.c_uint32 # enum
-class struct_asigma_data(Structure):
+class struct_c__SA_asigma_data(Structure):
     pass
 
-struct_asigma_data._pack_ = 1 # source:False
-struct_asigma_data._fields_ = [
+struct_c__SA_asigma_data._pack_ = 1 # source:False
+struct_c__SA_asigma_data._fields_ = [
     ('type', asigma_type),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('asigma_loc', asigma_loc_data),
 ]
 
-asigma_data = struct_asigma_data
-try:
-    asigma_free = _libraries['libascot.so'].asigma_free
-    asigma_free.restype = None
-    asigma_free.argtypes = [ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-try:
-    asigma_offload = _libraries['libascot.so'].asigma_offload
-    asigma_offload.restype = None
-    asigma_offload.argtypes = [ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-try:
-    asigma_extrapolate = _libraries['libascot.so'].asigma_extrapolate
-    asigma_extrapolate.restype = None
-    asigma_extrapolate.argtypes = [ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    asigma_eval_sigma = _libraries['libascot.so'].asigma_eval_sigma
-    asigma_eval_sigma.restype = a5err
-    asigma_eval_sigma.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, asigma_reac_type, ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-try:
-    asigma_eval_sigmav = _libraries['libascot.so'].asigma_eval_sigmav
-    asigma_eval_sigmav.restype = a5err
-    asigma_eval_sigmav.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, real, real, real, real, asigma_reac_type, ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-try:
-    asigma_eval_cx = _libraries['libascot.so'].asigma_eval_cx
-    asigma_eval_cx.restype = a5err
-    asigma_eval_cx.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-try:
-    asigma_eval_bms = _libraries['libascot.so'].asigma_eval_bms
-    asigma_eval_bms.restype = a5err
-    asigma_eval_bms.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_asigma_data)]
-except AttributeError:
-    pass
-class struct_nbi_injector(Structure):
+asigma_data = struct_c__SA_asigma_data
+asigma_free = _libraries['libascot.so'].asigma_free
+asigma_free.restype = None
+asigma_free.argtypes = [ctypes.POINTER(struct_c__SA_asigma_data)]
+asigma_offload = _libraries['libascot.so'].asigma_offload
+asigma_offload.restype = None
+asigma_offload.argtypes = [ctypes.POINTER(struct_c__SA_asigma_data)]
+asigma_extrapolate = _libraries['libascot.so'].asigma_extrapolate
+asigma_extrapolate.restype = None
+asigma_extrapolate.argtypes = [ctypes.c_int32]
+asigma_eval_sigma = _libraries['libascot.so'].asigma_eval_sigma
+asigma_eval_sigma.restype = a5err
+asigma_eval_sigma.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, real, asigma_reac_type, ctypes.POINTER(struct_c__SA_asigma_data)]
+asigma_eval_sigmav = _libraries['libascot.so'].asigma_eval_sigmav
+asigma_eval_sigmav.restype = a5err
+asigma_eval_sigmav.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, ctypes.c_int32, ctypes.c_int32, real, real, real, real, asigma_reac_type, ctypes.POINTER(struct_c__SA_asigma_data)]
+asigma_eval_cx = _libraries['libascot.so'].asigma_eval_cx
+asigma_eval_cx.restype = a5err
+asigma_eval_cx.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_c__SA_asigma_data)]
+asigma_eval_bms = _libraries['libascot.so'].asigma_eval_bms
+asigma_eval_bms.restype = a5err
+asigma_eval_bms.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.c_int32, real, real, ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), real, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_c__SA_asigma_data)]
+class struct_c__SA_nbi_injector(Structure):
     pass
 
-struct_nbi_injector._pack_ = 1 # source:False
-struct_nbi_injector._fields_ = [
+struct_c__SA_nbi_injector._pack_ = 1 # source:False
+struct_c__SA_nbi_injector._fields_ = [
     ('id', ctypes.c_int32),
     ('n_beamlet', ctypes.c_int32),
     ('beamlet_x', ctypes.POINTER(ctypes.c_double)),
@@ -2848,36 +2151,27 @@ struct_nbi_injector._fields_ = [
     ('mass', ctypes.c_double),
 ]
 
-nbi_injector = struct_nbi_injector
-class struct_nbi_data(Structure):
+nbi_injector = struct_c__SA_nbi_injector
+class struct_c__SA_nbi_data(Structure):
     pass
 
-struct_nbi_data._pack_ = 1 # source:False
-struct_nbi_data._fields_ = [
+struct_c__SA_nbi_data._pack_ = 1 # source:False
+struct_c__SA_nbi_data._fields_ = [
     ('ninj', ctypes.c_int32),
     ('PADDING_0', ctypes.c_ubyte * 4),
-    ('inj', ctypes.POINTER(struct_nbi_injector)),
+    ('inj', ctypes.POINTER(struct_c__SA_nbi_injector)),
 ]
 
-nbi_data = struct_nbi_data
-try:
-    nbi_init = _libraries['libascot.so'].nbi_init
-    nbi_init.restype = ctypes.c_int32
-    nbi_init.argtypes = [ctypes.POINTER(struct_nbi_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    nbi_free = _libraries['libascot.so'].nbi_free
-    nbi_free.restype = None
-    nbi_free.argtypes = [ctypes.POINTER(struct_nbi_data)]
-except AttributeError:
-    pass
-try:
-    nbi_inject = _libraries['libascot.so'].nbi_inject
-    nbi_inject.restype = None
-    nbi_inject.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_nbi_injector), ctypes.POINTER(ctypes.POINTER(None))]
-except AttributeError:
-    pass
+nbi_data = struct_c__SA_nbi_data
+nbi_init = _libraries['libascot.so'].nbi_init
+nbi_init.restype = ctypes.c_int32
+nbi_init.argtypes = [ctypes.POINTER(struct_c__SA_nbi_data), ctypes.c_int32, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double)]
+nbi_free = _libraries['libascot.so'].nbi_free
+nbi_free.restype = None
+nbi_free.argtypes = [ctypes.POINTER(struct_c__SA_nbi_data)]
+nbi_inject = _libraries['libascot.so'].nbi_inject
+nbi_inject.restype = None
+nbi_inject.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_c__SA_nbi_injector), ctypes.POINTER(ctypes.POINTER(None))]
 class struct_rfof_marker(Structure):
     pass
 
@@ -2891,70 +2185,43 @@ struct_rfof_marker._fields_ = [
 ]
 
 rfof_marker = struct_rfof_marker
-class struct_rfof_data(Structure):
+class struct_c__SA_rfof_data(Structure):
     pass
 
-struct_rfof_data._pack_ = 1 # source:False
-struct_rfof_data._fields_ = [
+struct_c__SA_rfof_data._pack_ = 1 # source:False
+struct_c__SA_rfof_data._fields_ = [
     ('rfof_input_params', ctypes.POINTER(None)),
     ('rfglobal', ctypes.POINTER(None)),
 ]
 
-rfof_data = struct_rfof_data
-try:
-    rfof_init = _libraries['libascot.so'].rfof_init
-    rfof_init.restype = None
-    rfof_init.argtypes = [ctypes.POINTER(struct_rfof_data)]
-except AttributeError:
-    pass
-try:
-    rfof_free = _libraries['libascot.so'].rfof_free
-    rfof_free.restype = None
-    rfof_free.argtypes = [ctypes.POINTER(struct_rfof_data)]
-except AttributeError:
-    pass
-try:
-    rfof_set_marker_manually = _libraries['libascot.so'].rfof_set_marker_manually
-    rfof_set_marker_manually.restype = None
-    rfof_set_marker_manually.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    rfof_set_up = _libraries['libascot.so'].rfof_set_up
-    rfof_set_up.restype = None
-    rfof_set_up.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_rfof_data)]
-except AttributeError:
-    pass
-try:
-    rfof_tear_down = _libraries['libascot.so'].rfof_tear_down
-    rfof_tear_down.restype = None
-    rfof_tear_down.argtypes = [ctypes.POINTER(struct_rfof_marker)]
-except AttributeError:
-    pass
-try:
-    rfof_clear_history = _libraries['libascot.so'].rfof_clear_history
-    rfof_clear_history.restype = None
-    rfof_clear_history.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    rfof_resonance_check_and_kick_gc = _libraries['libascot.so'].rfof_resonance_check_and_kick_gc
-    rfof_resonance_check_and_kick_gc.restype = None
-    rfof_resonance_check_and_kick_gc.argtypes = [ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_rfof_data), ctypes.POINTER(struct_B_field_data)]
-except AttributeError:
-    pass
-try:
-    rfof_eval_rf_wave = _libraries['libascot.so'].rfof_eval_rf_wave
-    rfof_eval_rf_wave.restype = None
-    rfof_eval_rf_wave.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_rfof_data)]
-except AttributeError:
-    pass
-try:
-    rfof_eval_resonance_function = _libraries['libascot.so'].rfof_eval_resonance_function
-    rfof_eval_resonance_function.restype = None
-    rfof_eval_resonance_function.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_rfof_data)]
-except AttributeError:
-    pass
+rfof_data = struct_c__SA_rfof_data
+rfof_init = _libraries['libascot.so'].rfof_init
+rfof_init.restype = None
+rfof_init.argtypes = [ctypes.POINTER(struct_c__SA_rfof_data)]
+rfof_free = _libraries['libascot.so'].rfof_free
+rfof_free.restype = None
+rfof_free.argtypes = [ctypes.POINTER(struct_c__SA_rfof_data)]
+rfof_set_marker_manually = _libraries['libascot.so'].rfof_set_marker_manually
+rfof_set_marker_manually.restype = None
+rfof_set_marker_manually.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32)]
+rfof_set_up = _libraries['libascot.so'].rfof_set_up
+rfof_set_up.restype = None
+rfof_set_up.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_c__SA_rfof_data)]
+rfof_tear_down = _libraries['libascot.so'].rfof_tear_down
+rfof_tear_down.restype = None
+rfof_tear_down.argtypes = [ctypes.POINTER(struct_rfof_marker)]
+rfof_clear_history = _libraries['libascot.so'].rfof_clear_history
+rfof_clear_history.restype = None
+rfof_clear_history.argtypes = [ctypes.POINTER(struct_rfof_marker), ctypes.c_int32]
+rfof_resonance_check_and_kick_gc = _libraries['libascot.so'].rfof_resonance_check_and_kick_gc
+rfof_resonance_check_and_kick_gc.restype = None
+rfof_resonance_check_and_kick_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_c__SA_rfof_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+rfof_eval_rf_wave = _libraries['libascot.so'].rfof_eval_rf_wave
+rfof_eval_rf_wave.restype = None
+rfof_eval_rf_wave.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), real, real, ctypes.POINTER(struct_c__SA_rfof_data)]
+rfof_eval_resonance_function = _libraries['libascot.so'].rfof_eval_resonance_function
+rfof_eval_resonance_function.restype = None
+rfof_eval_resonance_function.argtypes = [ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(struct_rfof_marker), ctypes.POINTER(struct_c__SA_rfof_data)]
 
 # values for enumeration 'SIMULATION_MODE'
 SIMULATION_MODE__enumvalues = {
@@ -2968,22 +2235,22 @@ simulate_mode_gc = 2
 simulate_mode_hybrid = 3
 simulate_mode_ml = 4
 SIMULATION_MODE = ctypes.c_uint32 # enum
-class struct_sim_data(Structure):
+class struct_c__SA_sim_data(Structure):
     pass
 
-class struct_mccc_data(Structure):
+class struct_c__SA_mccc_data(Structure):
     pass
 
-struct_mccc_data._pack_ = 1 # source:False
-struct_mccc_data._fields_ = [
+struct_c__SA_mccc_data._pack_ = 1 # source:False
+struct_c__SA_mccc_data._fields_ = [
     ('usetabulated', ctypes.c_int32),
     ('include_energy', ctypes.c_int32),
     ('include_pitch', ctypes.c_int32),
     ('include_gcdiff', ctypes.c_int32),
 ]
 
-struct_sim_data._pack_ = 1 # source:False
-struct_sim_data._fields_ = [
+struct_c__SA_sim_data._pack_ = 1 # source:False
+struct_c__SA_sim_data._fields_ = [
     ('B_data', B_field_data),
     ('E_data', E_field_data),
     ('plasma_data', plasma_data),
@@ -2996,7 +2263,7 @@ struct_sim_data._fields_ = [
     ('diag_data', diag_data),
     ('rfof_data', rfof_data),
     ('random_data', ctypes.POINTER(None)),
-    ('mccc_data', struct_mccc_data),
+    ('mccc_data', struct_c__SA_mccc_data),
     ('sim_mode', ctypes.c_int32),
     ('enable_ada', ctypes.c_int32),
     ('record_mode', ctypes.c_int32),
@@ -3050,19 +2317,13 @@ struct_sim_data._fields_ = [
     ('qid_nbi', ctypes.c_char * 256),
 ]
 
-sim_data = struct_sim_data
-try:
-    simulate_init = _libraries['libascot.so'].simulate_init
-    simulate_init.restype = None
-    simulate_init.argtypes = [ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
-try:
-    simulate = _libraries['libascot.so'].simulate
-    simulate.restype = None
-    simulate.argtypes = [ctypes.c_int32, ctypes.POINTER(struct_particle_state), ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
+sim_data = struct_c__SA_sim_data
+simulate_init = _libraries['libascot.so'].simulate_init
+simulate_init.restype = None
+simulate_init.argtypes = [ctypes.POINTER(struct_c__SA_sim_data)]
+simulate = _libraries['libascot.so'].simulate
+simulate.restype = None
+simulate.argtypes = [ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(struct_c__SA_sim_data)]
 
 # values for enumeration 'ENDCOND_FLAG'
 ENDCOND_FLAG__enumvalues = {
@@ -3092,39 +2353,24 @@ endcond_hybrid = 512
 endcond_neutr = 1024
 endcond_ioniz = 2048
 ENDCOND_FLAG = ctypes.c_uint32 # enum
-try:
-    endcond_check_gc = _libraries['libascot.so'].endcond_check_gc
-    endcond_check_gc.restype = None
-    endcond_check_gc.argtypes = [ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
-try:
-    endcond_check_fo = _libraries['libascot.so'].endcond_check_fo
-    endcond_check_fo.restype = None
-    endcond_check_fo.argtypes = [ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
-try:
-    endcond_check_ml = _libraries['libascot.so'].endcond_check_ml
-    endcond_check_ml.restype = None
-    endcond_check_ml.argtypes = [ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_particle_simd_ml), ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
-try:
-    endcond_parse = _libraries['libascot.so'].endcond_parse
-    endcond_parse.restype = None
-    endcond_parse.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    endcond_parse2str = _libraries['libascot.so'].endcond_parse2str
-    endcond_parse2str.restype = None
-    endcond_parse2str.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_char)]
-except AttributeError:
-    pass
+endcond_check_gc = _libraries['libascot.so'].endcond_check_gc
+endcond_check_gc.restype = None
+endcond_check_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_sim_data)]
+endcond_check_fo = _libraries['libascot.so'].endcond_check_fo
+endcond_check_fo.restype = None
+endcond_check_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_sim_data)]
+endcond_check_ml = _libraries['libascot.so'].endcond_check_ml
+endcond_check_ml.restype = None
+endcond_check_ml.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_particle_simd_ml), ctypes.POINTER(struct_c__SA_sim_data)]
+endcond_parse = _libraries['libascot.so'].endcond_parse
+endcond_parse.restype = None
+endcond_parse.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_int32)]
+endcond_parse2str = _libraries['libascot.so'].endcond_parse2str
+endcond_parse2str.restype = None
+endcond_parse2str.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_char)]
 
-# values for enumeration 'hist_coordinate'
-hist_coordinate__enumvalues = {
+# values for enumeration 'c__EA_hist_coordinate'
+c__EA_hist_coordinate__enumvalues = {
     0: 'R',
     1: 'PHI',
     2: 'Z',
@@ -3158,12 +2404,14 @@ MU = 12
 PTOR = 13
 TIME = 14
 CHARGE = 15
-hist_coordinate = ctypes.c_uint32 # enum
-class struct_hist_axis(Structure):
+c__EA_hist_coordinate = ctypes.c_uint32 # enum
+hist_coordinate = c__EA_hist_coordinate
+hist_coordinate__enumvalues = c__EA_hist_coordinate__enumvalues
+class struct_c__SA_hist_axis(Structure):
     pass
 
-struct_hist_axis._pack_ = 1 # source:False
-struct_hist_axis._fields_ = [
+struct_c__SA_hist_axis._pack_ = 1 # source:False
+struct_c__SA_hist_axis._fields_ = [
     ('name', hist_coordinate),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('min', ctypes.c_double),
@@ -3171,49 +2419,34 @@ struct_hist_axis._fields_ = [
     ('n', ctypes.c_uint64),
 ]
 
-hist_axis = struct_hist_axis
-class struct_histogram(Structure):
+hist_axis = struct_c__SA_hist_axis
+class struct_c__SA_histogram(Structure):
     pass
 
-struct_histogram._pack_ = 1 # source:False
-struct_histogram._fields_ = [
-    ('axes', struct_hist_axis * 16),
+struct_c__SA_histogram._pack_ = 1 # source:False
+struct_c__SA_histogram._fields_ = [
+    ('axes', struct_c__SA_hist_axis * 16),
     ('strides', ctypes.c_uint64 * 15),
     ('nbin', ctypes.c_uint64),
     ('bins', ctypes.POINTER(ctypes.c_double)),
 ]
 
-histogram = struct_histogram
-try:
-    hist_init = _libraries['libascot.so'].hist_init
-    hist_init.restype = ctypes.c_int32
-    hist_init.argtypes = [ctypes.POINTER(struct_histogram), ctypes.c_int32, ctypes.POINTER(hist_coordinate), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_uint64)]
-except AttributeError:
-    pass
-try:
-    hist_free = _libraries['libascot.so'].hist_free
-    hist_free.restype = None
-    hist_free.argtypes = [ctypes.POINTER(struct_histogram)]
-except AttributeError:
-    pass
-try:
-    hist_offload = _libraries['libascot.so'].hist_offload
-    hist_offload.restype = None
-    hist_offload.argtypes = [ctypes.POINTER(struct_histogram)]
-except AttributeError:
-    pass
-try:
-    hist_update_fo = _libraries['libascot.so'].hist_update_fo
-    hist_update_fo.restype = None
-    hist_update_fo.argtypes = [ctypes.POINTER(struct_histogram), ctypes.POINTER(struct_particle_simd_fo), ctypes.POINTER(struct_particle_simd_fo)]
-except AttributeError:
-    pass
-try:
-    hist_update_gc = _libraries['libascot.so'].hist_update_gc
-    hist_update_gc.restype = None
-    hist_update_gc.argtypes = [ctypes.POINTER(struct_histogram), ctypes.POINTER(struct_particle_simd_gc), ctypes.POINTER(struct_particle_simd_gc)]
-except AttributeError:
-    pass
+histogram = struct_c__SA_histogram
+hist_init = _libraries['libascot.so'].hist_init
+hist_init.restype = ctypes.c_int32
+hist_init.argtypes = [ctypes.POINTER(struct_c__SA_histogram), ctypes.c_int32, ctypes.POINTER(c__EA_hist_coordinate), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_uint64)]
+hist_free = _libraries['libascot.so'].hist_free
+hist_free.restype = None
+hist_free.argtypes = [ctypes.POINTER(struct_c__SA_histogram)]
+hist_offload = _libraries['libascot.so'].hist_offload
+hist_offload.restype = None
+hist_offload.argtypes = [ctypes.POINTER(struct_c__SA_histogram)]
+hist_update_fo = _libraries['libascot.so'].hist_update_fo
+hist_update_fo.restype = None
+hist_update_fo.argtypes = [ctypes.POINTER(struct_c__SA_histogram), ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+hist_update_gc = _libraries['libascot.so'].hist_update_gc
+hist_update_gc.restype = None
+hist_update_gc.argtypes = [ctypes.POINTER(struct_c__SA_histogram), ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.POINTER(struct_c__SA_particle_simd_gc)]
 
 # values for enumeration 'input_group'
 input_group__enumvalues = {
@@ -3241,60 +2474,33 @@ hdf5_input_mhd = 256
 hdf5_input_asigma = 512
 hdf5_input_nbi = 1024
 input_group = ctypes.c_uint32 # enum
-try:
-    hdf5_interface_read_input = _libraries['libascot.so'].hdf5_interface_read_input
-    hdf5_interface_read_input.restype = ctypes.c_int32
-    hdf5_interface_read_input.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.c_int32, ctypes.POINTER(ctypes.POINTER(struct_input_particle)), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    hdf5_interface_init_results = _libraries['libascot.so'].hdf5_interface_init_results
-    hdf5_interface_init_results.restype = ctypes.c_int32
-    hdf5_interface_init_results.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char)]
-except AttributeError:
-    pass
-try:
-    hdf5_interface_write_state = _libraries['libascot.so'].hdf5_interface_write_state
-    hdf5_interface_write_state.restype = ctypes.c_int32
-    hdf5_interface_write_state.argtypes = [ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char), integer, ctypes.POINTER(struct_particle_state)]
-except AttributeError:
-    pass
-try:
-    hdf5_interface_write_diagnostics = _libraries['libascot.so'].hdf5_interface_write_diagnostics
-    hdf5_interface_write_diagnostics.restype = ctypes.c_int32
-    hdf5_interface_write_diagnostics.argtypes = [ctypes.POINTER(struct_sim_data)]
-except AttributeError:
-    pass
-try:
-    hdf5_generate_qid = _libraries['libascot.so'].hdf5_generate_qid
-    hdf5_generate_qid.restype = None
-    hdf5_generate_qid.argtypes = [ctypes.POINTER(ctypes.c_char)]
-except AttributeError:
-    pass
-try:
-    libascot_allocate_input_particles = _libraries['libascot.so'].libascot_allocate_input_particles
-    libascot_allocate_input_particles.restype = ctypes.POINTER(struct_input_particle)
-    libascot_allocate_input_particles.argtypes = [ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    libascot_allocate_particle_states = _libraries['libascot.so'].libascot_allocate_particle_states
-    libascot_allocate_particle_states.restype = ctypes.POINTER(struct_particle_state)
-    libascot_allocate_particle_states.argtypes = [ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    libascot_allocate_reals = _libraries['libascot.so'].libascot_allocate_reals
-    libascot_allocate_reals.restype = ctypes.POINTER(ctypes.c_double)
-    libascot_allocate_reals.argtypes = [size_t]
-except AttributeError:
-    pass
-try:
-    libascot_deallocate = _libraries['libascot.so'].libascot_deallocate
-    libascot_deallocate.restype = None
-    libascot_deallocate.argtypes = [ctypes.POINTER(None)]
-except AttributeError:
-    pass
+hdf5_interface_read_input = _libraries['libascot.so'].hdf5_interface_read_input
+hdf5_interface_read_input.restype = ctypes.c_int32
+hdf5_interface_read_input.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.c_int32, ctypes.POINTER(ctypes.POINTER(struct_c__SA_input_particle)), ctypes.POINTER(ctypes.c_int32)]
+hdf5_interface_init_results = _libraries['libascot.so'].hdf5_interface_init_results
+hdf5_interface_init_results.restype = ctypes.c_int32
+hdf5_interface_init_results.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char)]
+hdf5_interface_write_state = _libraries['libascot.so'].hdf5_interface_write_state
+hdf5_interface_write_state.restype = ctypes.c_int32
+hdf5_interface_write_state.argtypes = [ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_char), integer, ctypes.POINTER(struct_c__SA_particle_state)]
+hdf5_interface_write_diagnostics = _libraries['libascot.so'].hdf5_interface_write_diagnostics
+hdf5_interface_write_diagnostics.restype = ctypes.c_int32
+hdf5_interface_write_diagnostics.argtypes = [ctypes.POINTER(struct_c__SA_sim_data)]
+hdf5_generate_qid = _libraries['libascot.so'].hdf5_generate_qid
+hdf5_generate_qid.restype = None
+hdf5_generate_qid.argtypes = [ctypes.POINTER(ctypes.c_char)]
+libascot_allocate_input_particles = _libraries['libascot.so'].libascot_allocate_input_particles
+libascot_allocate_input_particles.restype = ctypes.POINTER(struct_c__SA_input_particle)
+libascot_allocate_input_particles.argtypes = [ctypes.c_int32]
+libascot_allocate_particle_states = _libraries['libascot.so'].libascot_allocate_particle_states
+libascot_allocate_particle_states.restype = ctypes.POINTER(struct_c__SA_particle_state)
+libascot_allocate_particle_states.argtypes = [ctypes.c_int32]
+libascot_allocate_reals = _libraries['libascot.so'].libascot_allocate_reals
+libascot_allocate_reals.restype = ctypes.POINTER(ctypes.c_double)
+libascot_allocate_reals.argtypes = [size_t]
+libascot_deallocate = _libraries['libascot.so'].libascot_deallocate
+libascot_deallocate.restype = None
+libascot_deallocate.argtypes = [ctypes.POINTER(None)]
 
 # values for enumeration 'Reaction'
 Reaction__enumvalues = {
@@ -3308,44 +2514,37 @@ DHe3_He4p = 2
 DD_Tp = 3
 DD_He3n = 4
 Reaction = ctypes.c_uint32 # enum
-try:
-    boschhale_reaction = _libraries['libascot.so'].boschhale_reaction
-    boschhale_reaction.restype = None
-    boschhale_reaction.argtypes = [Reaction, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    boschhale_sigma = _libraries['libascot.so'].boschhale_sigma
-    boschhale_sigma.restype = real
-    boschhale_sigma.argtypes = [Reaction, real]
-except AttributeError:
-    pass
-try:
-    boschhale_sigmav = _libraries['libascot.so'].boschhale_sigmav
-    boschhale_sigmav.restype = real
-    boschhale_sigmav.argtypes = [Reaction, real]
-except AttributeError:
-    pass
+boschhale_reaction = _libraries['libascot.so'].boschhale_reaction
+boschhale_reaction.restype = None
+boschhale_reaction.argtypes = [Reaction, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+boschhale_sigma = _libraries['libascot.so'].boschhale_sigma
+boschhale_sigma.restype = real
+boschhale_sigma.argtypes = [Reaction, real]
+boschhale_sigmav = _libraries['libascot.so'].boschhale_sigmav
+boschhale_sigmav.restype = real
+boschhale_sigmav.argtypes = [Reaction, real]
 
-# values for enumeration 'mom_space_basis'
-mom_space_basis__enumvalues = {
+# values for enumeration 'c__EA_mom_space_basis'
+c__EA_mom_space_basis__enumvalues = {
     0: 'PPARPPERP',
     1: 'EKINXI',
 }
 PPARPPERP = 0
 EKINXI = 1
-mom_space_basis = ctypes.c_uint32 # enum
-class struct_afsi_data(Structure):
+c__EA_mom_space_basis = ctypes.c_uint32 # enum
+mom_space_basis = c__EA_mom_space_basis
+mom_space_basis__enumvalues = c__EA_mom_space_basis__enumvalues
+class struct_c__SA_afsi_data(Structure):
     pass
 
-struct_afsi_data._pack_ = 1 # source:False
-struct_afsi_data._fields_ = [
+struct_c__SA_afsi_data._pack_ = 1 # source:False
+struct_c__SA_afsi_data._fields_ = [
     ('type1', ctypes.c_int32),
     ('type2', ctypes.c_int32),
     ('thermal1', ctypes.c_int32),
     ('thermal2', ctypes.c_int32),
-    ('beam1', ctypes.POINTER(struct_histogram)),
-    ('beam2', ctypes.POINTER(struct_histogram)),
+    ('beam1', ctypes.POINTER(struct_c__SA_histogram)),
+    ('beam2', ctypes.POINTER(struct_c__SA_histogram)),
     ('r', ctypes.POINTER(ctypes.c_double)),
     ('phi', ctypes.POINTER(ctypes.c_double)),
     ('z', ctypes.POINTER(ctypes.c_double)),
@@ -3356,55 +2555,31 @@ struct_afsi_data._fields_ = [
     ('mult', ctypes.c_double),
 ]
 
-afsi_data = struct_afsi_data
-try:
-    afsi_run = _libraries['libascot.so'].afsi_run
-    afsi_run.restype = None
-    afsi_run.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.POINTER(struct_afsi_data), ctypes.c_int32, ctypes.POINTER(struct_histogram), ctypes.POINTER(struct_histogram)]
-except AttributeError:
-    pass
-try:
-    prepare_markers = _libraries['libascot.so'].prepare_markers
-    prepare_markers.restype = ctypes.c_int32
-    prepare_markers.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.c_int32, ctypes.POINTER(struct_input_particle), ctypes.POINTER(ctypes.POINTER(struct_particle_state)), ctypes.POINTER(ctypes.c_int32)]
-except AttributeError:
-    pass
-try:
-    write_rungroup = _libraries['libascot.so'].write_rungroup
-    write_rungroup.restype = ctypes.c_int32
-    write_rungroup.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.POINTER(struct_particle_state), ctypes.c_int32, ctypes.POINTER(ctypes.c_char)]
-except AttributeError:
-    pass
-try:
-    offload_and_simulate = _libraries['libascot.so'].offload_and_simulate
-    offload_and_simulate.restype = ctypes.c_int32
-    offload_and_simulate.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_particle_state), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.POINTER(struct_particle_state))]
-except AttributeError:
-    pass
-try:
-    write_output = _libraries['libascot.so'].write_output
-    write_output.restype = ctypes.c_int32
-    write_output.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.POINTER(struct_particle_state), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    print_marker_summary = _libraries['libascot.so'].print_marker_summary
-    print_marker_summary.restype = None
-    print_marker_summary.argtypes = [ctypes.POINTER(struct_particle_state), ctypes.c_int32]
-except AttributeError:
-    pass
-try:
-    biosaw_calc_B = _libraries['libascot.so'].biosaw_calc_B
-    biosaw_calc_B.restype = None
-    biosaw_calc_B.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
-except AttributeError:
-    pass
-try:
-    bbnbi_simulate = _libraries['libascot.so'].bbnbi_simulate
-    bbnbi_simulate.restype = None
-    bbnbi_simulate.argtypes = [ctypes.POINTER(struct_sim_data), ctypes.c_int32, real, real, ctypes.POINTER(ctypes.POINTER(struct_particle_state))]
-except AttributeError:
-    pass
+afsi_data = struct_c__SA_afsi_data
+afsi_run = _libraries['libascot.so'].afsi_run
+afsi_run.restype = None
+afsi_run.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.POINTER(struct_c__SA_afsi_data), ctypes.c_int32, ctypes.POINTER(struct_c__SA_histogram), ctypes.POINTER(struct_c__SA_histogram)]
+prepare_markers = _libraries['libascot.so'].prepare_markers
+prepare_markers.restype = ctypes.c_int32
+prepare_markers.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.c_int32, ctypes.POINTER(struct_c__SA_input_particle), ctypes.POINTER(ctypes.POINTER(struct_c__SA_particle_state)), ctypes.POINTER(ctypes.c_int32)]
+write_rungroup = _libraries['libascot.so'].write_rungroup
+write_rungroup.restype = ctypes.c_int32
+write_rungroup.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32, ctypes.POINTER(ctypes.c_char)]
+offload_and_simulate = _libraries['libascot.so'].offload_and_simulate
+offload_and_simulate.restype = ctypes.c_int32
+offload_and_simulate.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_state), ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.POINTER(struct_c__SA_particle_state))]
+write_output = _libraries['libascot.so'].write_output
+write_output.restype = ctypes.c_int32
+write_output.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32]
+print_marker_summary = _libraries['libascot.so'].print_marker_summary
+print_marker_summary.restype = None
+print_marker_summary.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32]
+biosaw_calc_B = _libraries['libascot.so'].biosaw_calc_B
+biosaw_calc_B.restype = None
+biosaw_calc_B.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.c_int32, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+bbnbi_simulate = _libraries['libascot.so'].bbnbi_simulate
+bbnbi_simulate.restype = None
+bbnbi_simulate.argtypes = [ctypes.POINTER(struct_c__SA_sim_data), ctypes.c_int32, real, real, ctypes.POINTER(ctypes.POINTER(struct_c__SA_particle_state))]
 __all__ = \
     ['B_2DS_data', 'B_2DS_eval_B', 'B_2DS_eval_B_dB',
     'B_2DS_eval_psi', 'B_2DS_eval_psi_dpsi', 'B_2DS_eval_rho_drho',
@@ -3449,12 +2624,13 @@ __all__ = \
     'asigma_type_loc', 'bbnbi_simulate', 'biosaw_calc_B',
     'boozer_data', 'boozer_eval_psithetazeta', 'boozer_free',
     'boozer_init', 'boozer_offload', 'boschhale_reaction',
-    'boschhale_sigma', 'boschhale_sigmav', 'diag_data', 'diag_free',
-    'diag_init', 'diag_offload', 'diag_onload',
-    'diag_orb_check_plane_crossing', 'diag_orb_check_radial_crossing',
-    'diag_orb_data', 'diag_orb_free', 'diag_orb_init',
-    'diag_orb_update_fo', 'diag_orb_update_gc', 'diag_orb_update_ml',
-    'diag_sum', 'diag_transcoef_data', 'diag_transcoef_free',
+    'boschhale_sigma', 'boschhale_sigmav', 'c__EA_hist_coordinate',
+    'c__EA_mom_space_basis', 'diag_data', 'diag_free', 'diag_init',
+    'diag_offload', 'diag_onload', 'diag_orb_check_plane_crossing',
+    'diag_orb_check_radial_crossing', 'diag_orb_data',
+    'diag_orb_free', 'diag_orb_init', 'diag_orb_update_fo',
+    'diag_orb_update_gc', 'diag_orb_update_ml', 'diag_sum',
+    'diag_transcoef_data', 'diag_transcoef_free',
     'diag_transcoef_init', 'diag_transcoef_link',
     'diag_transcoef_update_fo', 'diag_transcoef_update_gc',
     'diag_transcoef_update_ml', 'diag_update_fo', 'diag_update_gc',
@@ -3482,11 +2658,12 @@ __all__ = \
     'hdf5_input_options', 'hdf5_input_plasma', 'hdf5_input_wall',
     'hdf5_interface_init_results', 'hdf5_interface_read_input',
     'hdf5_interface_write_diagnostics', 'hdf5_interface_write_state',
-    'hist_axis', 'hist_coordinate', 'hist_free', 'hist_init',
-    'hist_offload', 'hist_update_fo', 'hist_update_gc', 'histogram',
-    'input_group', 'input_particle', 'input_particle_type',
-    'input_particle_type_gc', 'input_particle_type_ml',
-    'input_particle_type_p', 'input_particle_type_s', 'integer',
+    'hist_axis', 'hist_coordinate', 'hist_coordinate__enumvalues',
+    'hist_free', 'hist_init', 'hist_offload', 'hist_update_fo',
+    'hist_update_gc', 'histogram', 'input_group', 'input_particle',
+    'input_particle_type', 'input_particle_type_gc',
+    'input_particle_type_ml', 'input_particle_type_p',
+    'input_particle_type_s', 'integer',
     'libascot_allocate_input_particles',
     'libascot_allocate_particle_states', 'libascot_allocate_reals',
     'libascot_deallocate', 'mhd_data', 'mhd_eval', 'mhd_free',
@@ -3498,7 +2675,8 @@ __all__ = \
     'mhd_stat_data', 'mhd_stat_eval', 'mhd_stat_free',
     'mhd_stat_init', 'mhd_stat_offload', 'mhd_stat_perturbations',
     'mhd_type', 'mhd_type_nonstat', 'mhd_type_stat',
-    'mom_space_basis', 'mpi_gather_diag', 'mpi_gather_particlestate',
+    'mom_space_basis', 'mom_space_basis__enumvalues',
+    'mpi_gather_diag', 'mpi_gather_particlestate',
     'mpi_interface_barrier', 'mpi_interface_finalize',
     'mpi_interface_init', 'mpi_my_particles', 'nbi_data', 'nbi_free',
     'nbi_init', 'nbi_inject', 'nbi_injector', 'neutral_data',
@@ -3525,46 +2703,56 @@ __all__ = \
     'plasma_1D_init', 'plasma_1D_offload', 'plasma_1Dt_data',
     'plasma_1Dt_eval_dens', 'plasma_1Dt_eval_densandtemp',
     'plasma_1Dt_eval_flow', 'plasma_1Dt_eval_temp', 'plasma_1Dt_free',
-    'plasma_1Dt_init', 'plasma_1Dt_offload', 'plasma_data',
+    'plasma_1Dt_init', 'plasma_1Dt_offload', 'plasma_2D_data',
+    'plasma_2D_eval_dens', 'plasma_2D_eval_densandtemp',
+    'plasma_2D_eval_flow', 'plasma_2D_eval_temp', 'plasma_2D_free',
+    'plasma_2D_init', 'plasma_2D_offload', 'plasma_data',
     'plasma_eval_dens', 'plasma_eval_densandtemp', 'plasma_eval_flow',
     'plasma_eval_temp', 'plasma_free', 'plasma_get_n_species',
     'plasma_get_species_anum', 'plasma_get_species_charge',
     'plasma_get_species_mass', 'plasma_get_species_znum',
     'plasma_offload', 'plasma_type', 'plasma_type_1D',
-    'plasma_type_1DS', 'plasma_type_1Dt', 'prepare_markers',
-    'print_marker_summary', 'real', 'rfof_clear_history', 'rfof_data',
-    'rfof_eval_resonance_function', 'rfof_eval_rf_wave', 'rfof_free',
-    'rfof_init', 'rfof_marker', 'rfof_resonance_check_and_kick_gc',
-    'rfof_set_marker_manually', 'rfof_set_up', 'rfof_tear_down',
-    'sigma_CX', 'sigma_ioniz', 'sigma_recomb', 'sigmav_BMS',
-    'sigmav_CX', 'sigmav_ioniz', 'sigmav_recomb', 'sigmaveff_CX',
-    'sigmaveff_ioniz', 'sigmaveff_recomb', 'sim_data', 'simulate',
-    'simulate_init', 'simulate_mode_fo', 'simulate_mode_gc',
-    'simulate_mode_hybrid', 'simulate_mode_ml', 'size_t',
-    'struct_B_2DS_data', 'struct_B_3DS_data', 'struct_B_GS_data',
-    'struct_B_STS_data', 'struct_B_TC_data', 'struct_B_field_data',
-    'struct_E_1DS_data', 'struct_E_TC_data', 'struct_E_field_data',
-    'struct_N0_1D_data', 'struct_N0_3D_data', 'struct_afsi_data',
-    'struct_asigma_data', 'struct_asigma_loc_data',
-    'struct_boozer_data', 'struct_diag_data', 'struct_diag_orb_data',
-    'struct_diag_transcoef_data', 'struct_diag_transcoef_link',
-    'struct_dist_5D_data', 'struct_dist_6D_data',
-    'struct_dist_COM_data', 'struct_dist_rho5D_data',
-    'struct_dist_rho6D_data', 'struct_hist_axis', 'struct_histogram',
-    'struct_input_particle', 'struct_interp1D_data',
-    'struct_interp2D_data', 'struct_interp3D_data',
-    'struct_linint1D_data', 'struct_linint3D_data',
-    'struct_mccc_data', 'struct_mhd_data', 'struct_mhd_nonstat_data',
-    'struct_mhd_stat_data', 'struct_nbi_data', 'struct_nbi_injector',
-    'struct_neutral_data', 'struct_particle', 'struct_particle_gc',
-    'struct_particle_ml', 'struct_particle_queue',
-    'struct_particle_simd_fo', 'struct_particle_simd_gc',
-    'struct_particle_simd_ml', 'struct_particle_state',
-    'struct_plasma_1DS_data', 'struct_plasma_1D_data',
-    'struct_plasma_1Dt_data', 'struct_plasma_data',
-    'struct_rfof_data', 'struct_rfof_marker', 'struct_sim_data',
-    'struct_wall_2d_data', 'struct_wall_3d_data', 'struct_wall_data',
-    'union_input_particle_0', 'wall_2d_data',
+    'plasma_type_1DS', 'plasma_type_1Dt', 'plasma_type_2D',
+    'prepare_markers', 'print_marker_summary', 'real',
+    'rfof_clear_history', 'rfof_data', 'rfof_eval_resonance_function',
+    'rfof_eval_rf_wave', 'rfof_free', 'rfof_init', 'rfof_marker',
+    'rfof_resonance_check_and_kick_gc', 'rfof_set_marker_manually',
+    'rfof_set_up', 'rfof_tear_down', 'sigma_CX', 'sigma_ioniz',
+    'sigma_recomb', 'sigmav_BMS', 'sigmav_CX', 'sigmav_ioniz',
+    'sigmav_recomb', 'sigmaveff_CX', 'sigmaveff_ioniz',
+    'sigmaveff_recomb', 'sim_data', 'simulate', 'simulate_init',
+    'simulate_mode_fo', 'simulate_mode_gc', 'simulate_mode_hybrid',
+    'simulate_mode_ml', 'size_t', 'struct_c__SA_B_2DS_data',
+    'struct_c__SA_B_3DS_data', 'struct_c__SA_B_GS_data',
+    'struct_c__SA_B_STS_data', 'struct_c__SA_B_TC_data',
+    'struct_c__SA_B_field_data', 'struct_c__SA_E_1DS_data',
+    'struct_c__SA_E_TC_data', 'struct_c__SA_E_field_data',
+    'struct_c__SA_N0_1D_data', 'struct_c__SA_N0_3D_data',
+    'struct_c__SA_afsi_data', 'struct_c__SA_asigma_data',
+    'struct_c__SA_asigma_loc_data', 'struct_c__SA_boozer_data',
+    'struct_c__SA_diag_data', 'struct_c__SA_diag_orb_data',
+    'struct_c__SA_diag_transcoef_data', 'struct_c__SA_dist_5D_data',
+    'struct_c__SA_dist_6D_data', 'struct_c__SA_dist_COM_data',
+    'struct_c__SA_dist_rho5D_data', 'struct_c__SA_dist_rho6D_data',
+    'struct_c__SA_hist_axis', 'struct_c__SA_histogram',
+    'struct_c__SA_input_particle', 'struct_c__SA_interp1D_data',
+    'struct_c__SA_interp2D_data', 'struct_c__SA_interp3D_data',
+    'struct_c__SA_linint1D_data', 'struct_c__SA_linint2D_data',
+    'struct_c__SA_linint3D_data', 'struct_c__SA_mccc_data',
+    'struct_c__SA_mhd_data', 'struct_c__SA_mhd_nonstat_data',
+    'struct_c__SA_mhd_stat_data', 'struct_c__SA_nbi_data',
+    'struct_c__SA_nbi_injector', 'struct_c__SA_neutral_data',
+    'struct_c__SA_particle', 'struct_c__SA_particle_gc',
+    'struct_c__SA_particle_ml', 'struct_c__SA_particle_queue',
+    'struct_c__SA_particle_simd_fo', 'struct_c__SA_particle_simd_gc',
+    'struct_c__SA_particle_simd_ml', 'struct_c__SA_particle_state',
+    'struct_c__SA_plasma_1DS_data', 'struct_c__SA_plasma_1D_data',
+    'struct_c__SA_plasma_1Dt_data', 'struct_c__SA_plasma_2D_data',
+    'struct_c__SA_plasma_data', 'struct_c__SA_rfof_data',
+    'struct_c__SA_sim_data', 'struct_c__SA_wall_2d_data',
+    'struct_c__SA_wall_3d_data', 'struct_c__SA_wall_data',
+    'struct_diag_transcoef_link', 'struct_rfof_marker',
+    'union_c__SA_input_particle_0', 'wall_2d_data',
     'wall_2d_find_intersection', 'wall_2d_free', 'wall_2d_hit_wall',
     'wall_2d_init', 'wall_2d_inside', 'wall_2d_offload',
     'wall_3d_data', 'wall_3d_free', 'wall_3d_hit_wall',

--- a/a5py/ascotpy/ascot2py.py
+++ b/a5py/ascotpy/ascot2py.py
@@ -782,39 +782,40 @@ class struct_c__SA_particle_simd_gc(Structure):
 
 struct_c__SA_particle_simd_gc._pack_ = 1 # source:False
 struct_c__SA_particle_simd_gc._fields_ = [
-    ('r', ctypes.c_double * 16),
-    ('phi', ctypes.c_double * 16),
-    ('z', ctypes.c_double * 16),
-    ('ppar', ctypes.c_double * 16),
-    ('mu', ctypes.c_double * 16),
-    ('zeta', ctypes.c_double * 16),
-    ('mass', ctypes.c_double * 16),
-    ('charge', ctypes.c_double * 16),
-    ('time', ctypes.c_double * 16),
-    ('B_r', ctypes.c_double * 16),
-    ('B_phi', ctypes.c_double * 16),
-    ('B_z', ctypes.c_double * 16),
-    ('B_r_dr', ctypes.c_double * 16),
-    ('B_phi_dr', ctypes.c_double * 16),
-    ('B_z_dr', ctypes.c_double * 16),
-    ('B_r_dphi', ctypes.c_double * 16),
-    ('B_phi_dphi', ctypes.c_double * 16),
-    ('B_z_dphi', ctypes.c_double * 16),
-    ('B_r_dz', ctypes.c_double * 16),
-    ('B_phi_dz', ctypes.c_double * 16),
-    ('B_z_dz', ctypes.c_double * 16),
-    ('bounces', ctypes.c_int32 * 16),
-    ('weight', ctypes.c_double * 16),
-    ('cputime', ctypes.c_double * 16),
-    ('rho', ctypes.c_double * 16),
-    ('theta', ctypes.c_double * 16),
-    ('id', ctypes.c_int64 * 16),
-    ('endcond', ctypes.c_int64 * 16),
-    ('walltile', ctypes.c_int64 * 16),
-    ('mileage', ctypes.c_double * 16),
-    ('running', ctypes.c_int64 * 16),
-    ('err', ctypes.c_uint64 * 16),
-    ('index', ctypes.c_int64 * 16),
+    ('r', ctypes.POINTER(ctypes.c_double)),
+    ('phi', ctypes.POINTER(ctypes.c_double)),
+    ('z', ctypes.POINTER(ctypes.c_double)),
+    ('ppar', ctypes.POINTER(ctypes.c_double)),
+    ('mu', ctypes.POINTER(ctypes.c_double)),
+    ('zeta', ctypes.POINTER(ctypes.c_double)),
+    ('mass', ctypes.POINTER(ctypes.c_double)),
+    ('charge', ctypes.POINTER(ctypes.c_double)),
+    ('time', ctypes.POINTER(ctypes.c_double)),
+    ('B_r', ctypes.POINTER(ctypes.c_double)),
+    ('B_phi', ctypes.POINTER(ctypes.c_double)),
+    ('B_z', ctypes.POINTER(ctypes.c_double)),
+    ('B_r_dr', ctypes.POINTER(ctypes.c_double)),
+    ('B_phi_dr', ctypes.POINTER(ctypes.c_double)),
+    ('B_z_dr', ctypes.POINTER(ctypes.c_double)),
+    ('B_r_dphi', ctypes.POINTER(ctypes.c_double)),
+    ('B_phi_dphi', ctypes.POINTER(ctypes.c_double)),
+    ('B_z_dphi', ctypes.POINTER(ctypes.c_double)),
+    ('B_r_dz', ctypes.POINTER(ctypes.c_double)),
+    ('B_phi_dz', ctypes.POINTER(ctypes.c_double)),
+    ('B_z_dz', ctypes.POINTER(ctypes.c_double)),
+    ('bounces', ctypes.POINTER(ctypes.c_int32)),
+    ('weight', ctypes.POINTER(ctypes.c_double)),
+    ('cputime', ctypes.POINTER(ctypes.c_double)),
+    ('rho', ctypes.POINTER(ctypes.c_double)),
+    ('theta', ctypes.POINTER(ctypes.c_double)),
+    ('id', ctypes.POINTER(ctypes.c_int64)),
+    ('endcond', ctypes.POINTER(ctypes.c_int64)),
+    ('walltile', ctypes.POINTER(ctypes.c_int64)),
+    ('mileage', ctypes.POINTER(ctypes.c_double)),
+    ('running', ctypes.POINTER(ctypes.c_int64)),
+    ('err', ctypes.POINTER(ctypes.c_uint64)),
+    ('index', ctypes.POINTER(ctypes.c_int64)),
+    ('n_mrk', ctypes.c_uint64),
 ]
 
 particle_simd_gc = struct_c__SA_particle_simd_gc
@@ -857,6 +858,9 @@ particle_simd_ml = struct_c__SA_particle_simd_ml
 particle_allocate_fo = _libraries['libascot.so'].particle_allocate_fo
 particle_allocate_fo.restype = None
 particle_allocate_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32]
+particle_allocate_gc = _libraries['libascot.so'].particle_allocate_gc
+particle_allocate_gc.restype = None
+particle_allocate_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc), ctypes.c_int32]
 particle_to_fo_dummy = _libraries['libascot.so'].particle_to_fo_dummy
 particle_to_fo_dummy.restype = None
 particle_to_fo_dummy.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32]
@@ -893,6 +897,12 @@ particle_offload_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo)]
 particle_onload_fo = _libraries['libascot.so'].particle_onload_fo
 particle_onload_fo.restype = None
 particle_onload_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_fo)]
+particle_offload_gc = _libraries['libascot.so'].particle_offload_gc
+particle_offload_gc.restype = None
+particle_offload_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc)]
+particle_onload_gc = _libraries['libascot.so'].particle_onload_gc
+particle_onload_gc.restype = None
+particle_onload_gc.argtypes = [ctypes.POINTER(struct_c__SA_particle_simd_gc)]
 particle_state_to_fo = _libraries['libascot.so'].particle_state_to_fo
 particle_state_to_fo.restype = a5err
 particle_state_to_fo.argtypes = [ctypes.POINTER(struct_c__SA_particle_state), ctypes.c_int32, ctypes.POINTER(struct_c__SA_particle_simd_fo), ctypes.c_int32, ctypes.POINTER(struct_c__SA_B_field_data)]
@@ -2262,7 +2272,7 @@ struct_c__SA_sim_data._fields_ = [
     ('nbi_data', nbi_data),
     ('diag_data', diag_data),
     ('rfof_data', rfof_data),
-    ('random_data', ctypes.POINTER(None)),
+    ('random_data', ctypes.POINTER(ctypes.POINTER(None))),
     ('mccc_data', struct_c__SA_mccc_data),
     ('sim_mode', ctypes.c_int32),
     ('enable_ada', ctypes.c_int32),
@@ -2683,16 +2693,17 @@ __all__ = \
     'neutral_eval_n0', 'neutral_eval_t0', 'neutral_free',
     'neutral_get_n_species', 'neutral_offload', 'neutral_type',
     'neutral_type_1D', 'neutral_type_3D', 'offload_and_simulate',
-    'particle', 'particle_allocate_fo', 'particle_copy_fo',
-    'particle_copy_gc', 'particle_copy_ml', 'particle_cycle_fo',
-    'particle_cycle_gc', 'particle_cycle_ml', 'particle_fo_to_gc',
-    'particle_fo_to_state', 'particle_gc', 'particle_gc_to_state',
-    'particle_input_gc_to_state', 'particle_input_ml_to_state',
-    'particle_input_p_to_state', 'particle_input_to_state',
-    'particle_ml', 'particle_ml_to_state', 'particle_offload_fo',
-    'particle_onload_fo', 'particle_queue', 'particle_simd_fo',
-    'particle_simd_gc', 'particle_simd_ml', 'particle_state',
-    'particle_state_to_fo', 'particle_state_to_gc',
+    'particle', 'particle_allocate_fo', 'particle_allocate_gc',
+    'particle_copy_fo', 'particle_copy_gc', 'particle_copy_ml',
+    'particle_cycle_fo', 'particle_cycle_gc', 'particle_cycle_ml',
+    'particle_fo_to_gc', 'particle_fo_to_state', 'particle_gc',
+    'particle_gc_to_state', 'particle_input_gc_to_state',
+    'particle_input_ml_to_state', 'particle_input_p_to_state',
+    'particle_input_to_state', 'particle_ml', 'particle_ml_to_state',
+    'particle_offload_fo', 'particle_offload_gc',
+    'particle_onload_fo', 'particle_onload_gc', 'particle_queue',
+    'particle_simd_fo', 'particle_simd_gc', 'particle_simd_ml',
+    'particle_state', 'particle_state_to_fo', 'particle_state_to_gc',
     'particle_state_to_ml', 'particle_to_fo_dummy',
     'particle_to_gc_dummy', 'particle_to_ml_dummy', 'plasma_1DS_data',
     'plasma_1DS_eval_dens', 'plasma_1DS_eval_densandtemp',

--- a/a5py/ascotpy/ascot2py.py
+++ b/a5py/ascotpy/ascot2py.py
@@ -553,14 +553,35 @@ E_1DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_E_1DS_data)]
 E_1DS_eval_E = _libraries['libascot.so'].E_1DS_eval_E
 E_1DS_eval_E.restype = a5err
 E_1DS_eval_E.argtypes = [ctypes.c_double * 3, real, real, real, ctypes.POINTER(struct_c__SA_E_1DS_data), ctypes.POINTER(struct_c__SA_B_field_data)]
+class struct_c__SA_E_2DS_data(Structure):
+    _pack_ = 1 # source:False
+    _fields_ = [
+    ('vpot', struct_c__SA_interp2D_data),
+     ]
+
+E_2DS_data = struct_c__SA_E_2DS_data
+E_2DS_init = _libraries['libascot.so'].E_2DS_init
+E_2DS_init.restype = ctypes.c_int32
+E_2DS_init.argtypes = [ctypes.POINTER(struct_c__SA_E_2DS_data), ctypes.c_int32, real, real, ctypes.c_int32, real, real, ctypes.POINTER(ctypes.c_double)]
+E_2DS_free = _libraries['libascot.so'].E_2DS_free
+E_2DS_free.restype = None
+E_2DS_free.argtypes = [ctypes.POINTER(struct_c__SA_E_2DS_data)]
+E_2DS_offload = _libraries['libascot.so'].E_2DS_offload
+E_2DS_offload.restype = None
+E_2DS_offload.argtypes = [ctypes.POINTER(struct_c__SA_E_2DS_data)]
+E_2DS_eval_E = _libraries['libascot.so'].E_2DS_eval_E
+E_2DS_eval_E.restype = a5err
+E_2DS_eval_E.argtypes = [ctypes.c_double * 3, real, real, ctypes.POINTER(struct_c__SA_E_2DS_data)]
 
 # values for enumeration 'E_field_type'
 E_field_type__enumvalues = {
     0: 'E_field_type_TC',
     1: 'E_field_type_1DS',
+    2: 'E_field_type_2DS',
 }
 E_field_type_TC = 0
 E_field_type_1DS = 1
+E_field_type_2DS = 2
 E_field_type = ctypes.c_uint32 # enum
 class struct_c__SA_E_field_data(Structure):
     pass
@@ -571,6 +592,7 @@ struct_c__SA_E_field_data._fields_ = [
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('ETC', E_TC_data),
     ('E1DS', E_1DS_data),
+    ('E2DS', E_2DS_data),
 ]
 
 E_field_data = struct_c__SA_E_field_data
@@ -2614,20 +2636,21 @@ __all__ = \
     'B_field_type_TC', 'CHARGE', 'DD_He3n', 'DD_Tp', 'DHe3_He4p',
     'DT_He4n', 'EKIN', 'EKINXI', 'ENDCOND_FLAG', 'E_1DS_data',
     'E_1DS_eval_E', 'E_1DS_free', 'E_1DS_init', 'E_1DS_offload',
-    'E_TC_data', 'E_TC_eval_E', 'E_TC_free', 'E_TC_init',
-    'E_TC_offload', 'E_field_data', 'E_field_eval_E', 'E_field_free',
-    'E_field_offload', 'E_field_type', 'E_field_type_1DS',
-    'E_field_type_TC', 'MU', 'N0_1D_data', 'N0_1D_eval_n0',
-    'N0_1D_eval_t0', 'N0_1D_free', 'N0_1D_get_n_species',
-    'N0_1D_init', 'N0_1D_offload', 'N0_3D_data', 'N0_3D_eval_n0',
-    'N0_3D_eval_t0', 'N0_3D_free', 'N0_3D_get_n_species',
-    'N0_3D_init', 'N0_3D_offload', 'PHI', 'PPAR', 'PPARPPERP',
-    'PPERP', 'PPHI', 'PR', 'PTOR', 'PZ', 'R', 'RHO', 'Reaction',
-    'SIMULATION_MODE', 'THETA', 'TIME', 'XI', 'Z', 'a5err',
-    'afsi_data', 'afsi_run', 'asigma_data', 'asigma_eval_bms',
-    'asigma_eval_cx', 'asigma_eval_sigma', 'asigma_eval_sigmav',
-    'asigma_extrapolate', 'asigma_free', 'asigma_loc_data',
-    'asigma_loc_eval_bms', 'asigma_loc_eval_cx',
+    'E_2DS_data', 'E_2DS_eval_E', 'E_2DS_free', 'E_2DS_init',
+    'E_2DS_offload', 'E_TC_data', 'E_TC_eval_E', 'E_TC_free',
+    'E_TC_init', 'E_TC_offload', 'E_field_data', 'E_field_eval_E',
+    'E_field_free', 'E_field_offload', 'E_field_type',
+    'E_field_type_1DS', 'E_field_type_2DS', 'E_field_type_TC', 'MU',
+    'N0_1D_data', 'N0_1D_eval_n0', 'N0_1D_eval_t0', 'N0_1D_free',
+    'N0_1D_get_n_species', 'N0_1D_init', 'N0_1D_offload',
+    'N0_3D_data', 'N0_3D_eval_n0', 'N0_3D_eval_t0', 'N0_3D_free',
+    'N0_3D_get_n_species', 'N0_3D_init', 'N0_3D_offload', 'PHI',
+    'PPAR', 'PPARPPERP', 'PPERP', 'PPHI', 'PR', 'PTOR', 'PZ', 'R',
+    'RHO', 'Reaction', 'SIMULATION_MODE', 'THETA', 'TIME', 'XI', 'Z',
+    'a5err', 'afsi_data', 'afsi_run', 'asigma_data',
+    'asigma_eval_bms', 'asigma_eval_cx', 'asigma_eval_sigma',
+    'asigma_eval_sigmav', 'asigma_extrapolate', 'asigma_free',
+    'asigma_loc_data', 'asigma_loc_eval_bms', 'asigma_loc_eval_cx',
     'asigma_loc_eval_sigma', 'asigma_loc_eval_sigmav',
     'asigma_loc_free', 'asigma_loc_init', 'asigma_loc_offload',
     'asigma_offload', 'asigma_reac_type', 'asigma_type',
@@ -2737,38 +2760,38 @@ __all__ = \
     'struct_c__SA_B_3DS_data', 'struct_c__SA_B_GS_data',
     'struct_c__SA_B_STS_data', 'struct_c__SA_B_TC_data',
     'struct_c__SA_B_field_data', 'struct_c__SA_E_1DS_data',
-    'struct_c__SA_E_TC_data', 'struct_c__SA_E_field_data',
-    'struct_c__SA_N0_1D_data', 'struct_c__SA_N0_3D_data',
-    'struct_c__SA_afsi_data', 'struct_c__SA_asigma_data',
-    'struct_c__SA_asigma_loc_data', 'struct_c__SA_boozer_data',
-    'struct_c__SA_diag_data', 'struct_c__SA_diag_orb_data',
-    'struct_c__SA_diag_transcoef_data', 'struct_c__SA_dist_5D_data',
-    'struct_c__SA_dist_6D_data', 'struct_c__SA_dist_COM_data',
-    'struct_c__SA_dist_rho5D_data', 'struct_c__SA_dist_rho6D_data',
-    'struct_c__SA_hist_axis', 'struct_c__SA_histogram',
-    'struct_c__SA_input_particle', 'struct_c__SA_interp1D_data',
-    'struct_c__SA_interp2D_data', 'struct_c__SA_interp3D_data',
-    'struct_c__SA_linint1D_data', 'struct_c__SA_linint2D_data',
-    'struct_c__SA_linint3D_data', 'struct_c__SA_mccc_data',
-    'struct_c__SA_mhd_data', 'struct_c__SA_mhd_nonstat_data',
-    'struct_c__SA_mhd_stat_data', 'struct_c__SA_nbi_data',
-    'struct_c__SA_nbi_injector', 'struct_c__SA_neutral_data',
-    'struct_c__SA_particle', 'struct_c__SA_particle_gc',
-    'struct_c__SA_particle_ml', 'struct_c__SA_particle_queue',
-    'struct_c__SA_particle_simd_fo', 'struct_c__SA_particle_simd_gc',
-    'struct_c__SA_particle_simd_ml', 'struct_c__SA_particle_state',
-    'struct_c__SA_plasma_1DS_data', 'struct_c__SA_plasma_1D_data',
-    'struct_c__SA_plasma_1Dt_data', 'struct_c__SA_plasma_2D_data',
-    'struct_c__SA_plasma_data', 'struct_c__SA_rfof_data',
-    'struct_c__SA_sim_data', 'struct_c__SA_wall_2d_data',
-    'struct_c__SA_wall_3d_data', 'struct_c__SA_wall_data',
-    'struct_diag_transcoef_link', 'struct_rfof_marker',
-    'union_c__SA_input_particle_0', 'wall_2d_data',
-    'wall_2d_find_intersection', 'wall_2d_free', 'wall_2d_hit_wall',
-    'wall_2d_init', 'wall_2d_inside', 'wall_2d_offload',
-    'wall_3d_data', 'wall_3d_free', 'wall_3d_hit_wall',
-    'wall_3d_hit_wall_full', 'wall_3d_init', 'wall_3d_init_tree',
-    'wall_3d_offload', 'wall_3d_quad_collision',
+    'struct_c__SA_E_2DS_data', 'struct_c__SA_E_TC_data',
+    'struct_c__SA_E_field_data', 'struct_c__SA_N0_1D_data',
+    'struct_c__SA_N0_3D_data', 'struct_c__SA_afsi_data',
+    'struct_c__SA_asigma_data', 'struct_c__SA_asigma_loc_data',
+    'struct_c__SA_boozer_data', 'struct_c__SA_diag_data',
+    'struct_c__SA_diag_orb_data', 'struct_c__SA_diag_transcoef_data',
+    'struct_c__SA_dist_5D_data', 'struct_c__SA_dist_6D_data',
+    'struct_c__SA_dist_COM_data', 'struct_c__SA_dist_rho5D_data',
+    'struct_c__SA_dist_rho6D_data', 'struct_c__SA_hist_axis',
+    'struct_c__SA_histogram', 'struct_c__SA_input_particle',
+    'struct_c__SA_interp1D_data', 'struct_c__SA_interp2D_data',
+    'struct_c__SA_interp3D_data', 'struct_c__SA_linint1D_data',
+    'struct_c__SA_linint2D_data', 'struct_c__SA_linint3D_data',
+    'struct_c__SA_mccc_data', 'struct_c__SA_mhd_data',
+    'struct_c__SA_mhd_nonstat_data', 'struct_c__SA_mhd_stat_data',
+    'struct_c__SA_nbi_data', 'struct_c__SA_nbi_injector',
+    'struct_c__SA_neutral_data', 'struct_c__SA_particle',
+    'struct_c__SA_particle_gc', 'struct_c__SA_particle_ml',
+    'struct_c__SA_particle_queue', 'struct_c__SA_particle_simd_fo',
+    'struct_c__SA_particle_simd_gc', 'struct_c__SA_particle_simd_ml',
+    'struct_c__SA_particle_state', 'struct_c__SA_plasma_1DS_data',
+    'struct_c__SA_plasma_1D_data', 'struct_c__SA_plasma_1Dt_data',
+    'struct_c__SA_plasma_2D_data', 'struct_c__SA_plasma_data',
+    'struct_c__SA_rfof_data', 'struct_c__SA_sim_data',
+    'struct_c__SA_wall_2d_data', 'struct_c__SA_wall_3d_data',
+    'struct_c__SA_wall_data', 'struct_diag_transcoef_link',
+    'struct_rfof_marker', 'union_c__SA_input_particle_0',
+    'wall_2d_data', 'wall_2d_find_intersection', 'wall_2d_free',
+    'wall_2d_hit_wall', 'wall_2d_init', 'wall_2d_inside',
+    'wall_2d_offload', 'wall_3d_data', 'wall_3d_free',
+    'wall_3d_hit_wall', 'wall_3d_hit_wall_full', 'wall_3d_init',
+    'wall_3d_init_tree', 'wall_3d_offload', 'wall_3d_quad_collision',
     'wall_3d_tri_collision', 'wall_3d_tri_in_cube', 'wall_data',
     'wall_free', 'wall_get_flag', 'wall_get_n_elements',
     'wall_hit_wall', 'wall_offload', 'wall_type', 'wall_type_2D',

--- a/a5py/routines/plotting.py
+++ b/a5py/routines/plotting.py
@@ -596,7 +596,7 @@ def hist2d(x, y, xbins=None, ybins=None, weights=None, xlog="linear",
 
 @openfigureifnoaxes(projection=None)
 def mesh1d(x, y, xlabel=None, ylabel=None, axes=None,
-           logscale=False, label=None):
+           logscale=False, label=None, color=None):
     """Plot 1D distribution.
 
     Parameters
@@ -615,6 +615,8 @@ def mesh1d(x, y, xlabel=None, ylabel=None, axes=None,
         Whether the plot is in logarithmic scale.
     label : str, optional
         Label if you are using a legend.
+    color : str, optional
+        Color of the line.
     """
     xc = np.zeros((y.size*2,))
     xc[1:-1:2] = x[1:-1]
@@ -630,7 +632,7 @@ def mesh1d(x, y, xlabel=None, ylabel=None, axes=None,
     axes.set_xlim(x[0], x[-1])
     if logscale:
         axes.set_yscale('log')
-    axes.plot(xc, yc,label=label)
+    axes.plot(xc, yc, label=label, color=color)
 
 @openfigureifnoaxes(projection=None)
 def mesh2d(x, y, z, logscale=False, diverging=False, xlabel=None, ylabel=None,

--- a/a5py/routines/runmixin.py
+++ b/a5py/routines/runmixin.py
@@ -769,9 +769,18 @@ class RunMixin(DistMixin):
             nrho   = dist.abscissa_edges("rho").size
             ntheta = dist.abscissa_edges("theta").size
             nphi   = dist.abscissa_edges("phi").size
+
+            rho_edges = dist.abscissa_edges("rho")
+            minrho = float(rho_edges[0].v)  if hasattr(rho_edges[0],  "v") \
+                else float(rho_edges[0])
+            maxrho = float(rho_edges[-1].v) if hasattr(rho_edges[-1], "v") \
+                else float(rho_edges[-1])
+            
             volume, area, r, phi, z = self._root._ascot.input_rhovolume(
                 method=volmethod, tol=1e-1, nrho=nrho, ntheta=ntheta, nphi=nphi,
-                return_area=True, return_coords=True)
+                return_area=True, return_coords=True,
+                minrho=minrho, maxrho=maxrho)
+            
             volume[volume == 0] = 1e-8 # To avoid division by zero
             out = DistMoment(
                 dist.abscissa_edges("rho"), dist.abscissa_edges("theta"),

--- a/a5py/templates/__init__.py
+++ b/a5py/templates/__init__.py
@@ -7,9 +7,11 @@ from .importdata import ImportData
 from .imasinterface import ImportImas
 from .convertascot4 import Ascot4Templates
 from .nextstepfusioninterface import ImportNSF
+from .novatroninterface import ImportNovatron
 
 class Template(AnalyticalInputs, OptionTemplates, PoincareTemplates,
-                ImportData, ImportImas, Ascot4Templates, ImportNSF):
+                ImportData, ImportImas, Ascot4Templates, ImportNSF,
+                ImportNovatron):
     """Class for creating input data from templates or imported data.
 
     The templates are constructed by calling :meth:`construct` and specifying

--- a/a5py/templates/imasinterface.py
+++ b/a5py/templates/imasinterface.py
@@ -673,10 +673,6 @@ class ImportImas():
             "etemperature":etemperature,
         }
 
-        pls = self._ascot.data.create_input(
-            "import plasma profiles", dryrun=True, pls=pls,
-            extrapolate=3.0, extrapolate_len=0.001
-            )
         return "plasma_1D", pls
 
     def imas_marker(self, distribution_sources_ids=None):

--- a/a5py/templates/novatroninterface.py
+++ b/a5py/templates/novatroninterface.py
@@ -4,6 +4,8 @@ import numpy as np
 import h5py
 import unyt
 
+from a5py.physlib import species
+
 class ImportNovatron():
 
     def novatron_bfield(self, filename=None):
@@ -58,4 +60,36 @@ class ImportNovatron():
         with h5py.File(filename) as h5:
             r = h5["r"][:]
             z = h5["z"][:]
-            #psi = h5["psi_p"][:]
+            Te = h5["T_e"][:]
+            Ti = h5["T_i"][:]
+            density = h5["density_total"][:]
+
+        z = np.hstack((-z[::-1], z[1:]))
+        Te = np.hstack((np.fliplr(Te[:, 1:]), Te))
+        Ti = np.hstack((np.fliplr(Ti[:, 1:]), Ti))
+        density = np.hstack((np.fliplr(density[:, 1:]), density))
+
+        ni = np.zeros((r.size, z.size, 2))
+        ni[:, :, 0] = density / 2
+        ni[:, :, 1] = density / 2
+
+        D, T = species.species("D"), species.species("T")
+        pls = {
+            "rmin": r[0],
+            "rmax": r[-1],
+            "nr": r.size,
+            "zmin": z[0],
+            "zmax": z[-1],
+            "nz": z.size,
+            "nion": 2,
+            "anum": [D["anum"], T["anum"]],
+            "znum": [D["znum"], T["znum"]],
+            "mass": [D["mass"], T["mass"]],
+            "charge": [1, 1],
+            "vtor": density * 0,
+            "edensity": density,
+            "etemperature": Te,
+            "idensity": ni,
+            "itemperature": Ti,
+        }
+        return "plasma_2D", pls

--- a/a5py/templates/novatroninterface.py
+++ b/a5py/templates/novatroninterface.py
@@ -1,0 +1,61 @@
+"""Import data from Novatron.
+"""
+import numpy as np
+import h5py
+import unyt
+
+class ImportNovatron():
+
+    def novatron_bfield(self, filename=None):
+        with h5py.File(filename) as h5:
+            r = h5["r"][:]
+            z = h5["z"][:]
+            psi = h5["psi"][:]
+
+        z = np.hstack((-z[::-1], z[1:]))
+        psi = np.hstack((np.fliplr(psi[:, 1:]), psi))
+
+        b2ds = {
+            "rmin": r[0],
+            "rmax": r[-1],
+            "nr": r.size,
+            "zmin": z[0],
+            "zmax": z[-1],
+            "nz": z.size,
+            "psi": psi,
+            "br": psi*0,
+            "bphi": psi*0,
+            "bz": psi*0,
+            "axisr": 0,
+            "axisz": 0,
+            "psi0": np.amin(psi),
+            "psi1": np.amax(psi),
+        }
+
+        return "B_2DS", b2ds
+
+    def novatron_efield(self, filename=None):
+        with h5py.File(filename) as h5:
+            r = h5["r"][:]
+            z = h5["z"][:]
+            phi = h5["phi"][:]
+
+        z = np.hstack((-z[::-1], z[1:]))
+        phi = np.hstack((np.fliplr(phi[:, 1:]), phi))
+
+        e2ds = {
+            "rmin": r[0],
+            "rmax": r[-1],
+            "nr": r.size,
+            "zmin": z[0],
+            "zmax": z[-1],
+            "nz": z.size,
+            "vpot": phi,
+        }
+        return "E_2DS", e2ds
+
+    def novatron_plasma(self, filename=None):
+        with h5py.File(filename) as h5:
+            r = h5["r"][:]
+            z = h5["z"][:]
+            #psi = h5["psi_p"][:]

--- a/src/Bfield/B_3DS.c
+++ b/src/Bfield/B_3DS.c
@@ -151,6 +151,16 @@ int B_3DS_init(B_3DS_data* data,
         return 1;
     }
 
+    /* B_3DS_eval_B() and B_3DS_eval_B_dB() evaluate the three components with
+       interp3Dcomp_eval_f3() and interp3Dcomp_eval_df3(), which read all grid
+       metadata from the first component. The three splines are set up above
+       from the same grid parameters, so this always holds; check it here, once,
+       so that it cannot silently stop holding. */
+    if(!interp3Dcomp_same_grid(&data->B_r, &data->B_phi, &data->B_z)) {
+        print_err("Error: B components are not on the same grid.\n");
+        return 1;
+    }
+
     /* Evaluate psi and magnetic field on axis for checks */
     real psival[1], Bval[3];
     err = B_3DS_eval_psi(psival, data->axis_r, 0, data->axis_z, data);
@@ -318,9 +328,12 @@ a5err B_3DS_eval_B(real B[3], real r, real phi, real z, B_3DS_data* Bdata) {
     a5err err = 0;
     int interperr = 0;
 
-    interperr += interp3Dcomp_eval_f(&B[0], &Bdata->B_r, r, phi, z);
-    interperr += interp3Dcomp_eval_f(&B[1], &Bdata->B_phi, r, phi, z);
-    interperr += interp3Dcomp_eval_f(&B[2], &Bdata->B_z, r, phi, z);
+    /* The three components are splines on one and the same grid, so a single
+       call evaluates them all, locating the cell and evaluating the spline
+       basis polynomials once instead of three times. B_3DS_init() has checked
+       that the grids really do match. */
+    interperr += interp3Dcomp_eval_f3(B, &Bdata->B_r, &Bdata->B_phi,
+                                      &Bdata->B_z, r, phi, z);
 
     /* Test for B field interpolation error */
     if(interperr) {
@@ -365,25 +378,14 @@ a5err B_3DS_eval_B_dB(real B_dB[12], real r, real phi, real z,
                       B_3DS_data* Bdata) {
     a5err err = 0;
     int interperr = 0; /* If error happened during interpolation */
-    real B_dB_temp[4];
 
-    interperr += interp3Dcomp_eval_df(B_dB_temp, &Bdata->B_r, r, phi, z);
-    B_dB[0] = B_dB_temp[0];
-    B_dB[1] = B_dB_temp[1];
-    B_dB[2] = B_dB_temp[2];
-    B_dB[3] = B_dB_temp[3];
-
-    interperr += interp3Dcomp_eval_df(B_dB_temp, &Bdata->B_phi, r, phi, z);
-    B_dB[4] = B_dB_temp[0];
-    B_dB[5] = B_dB_temp[1];
-    B_dB[6] = B_dB_temp[2];
-    B_dB[7] = B_dB_temp[3];
-
-    interperr += interp3Dcomp_eval_df(B_dB_temp, &Bdata->B_z, r, phi, z);
-    B_dB[8] = B_dB_temp[0];
-    B_dB[9] = B_dB_temp[1];
-    B_dB[10] = B_dB_temp[2];
-    B_dB[11] = B_dB_temp[3];
+    /* The three components are splines on one and the same grid, so a single
+       call evaluates them all, locating the cell and evaluating the spline
+       basis polynomials once instead of three times. B_3DS_init() has checked
+       that the grids really do match. Each component writes four consecutive
+       values, which is already the B_dB layout, so no temporary is needed. */
+    interperr += interp3Dcomp_eval_df3(B_dB, &Bdata->B_r, &Bdata->B_phi,
+                                       &Bdata->B_z, r, phi, z);
 
     /* Test for B field interpolation error */
     if(interperr) {

--- a/src/Bfield/B_3DS.c
+++ b/src/Bfield/B_3DS.c
@@ -365,7 +365,7 @@ a5err B_3DS_eval_B_dB(real B_dB[12], real r, real phi, real z,
                       B_3DS_data* Bdata) {
     a5err err = 0;
     int interperr = 0; /* If error happened during interpolation */
-    real B_dB_temp[10];
+    real B_dB_temp[4];
 
     interperr += interp3Dcomp_eval_df(B_dB_temp, &Bdata->B_r, r, phi, z);
     B_dB[0] = B_dB_temp[0];

--- a/src/Bfield/B_STS.c
+++ b/src/Bfield/B_STS.c
@@ -245,7 +245,7 @@ a5err B_STS_eval_psi_dpsi(real psi_dpsi[4], real r, real phi, real z,
                           B_STS_data* Bdata) {
     a5err err = 0;
     int interperr = 0; /* If error happened during interpolation */
-    real psi_dpsi_temp[10];
+    real psi_dpsi_temp[4];
 
     interperr += interp3Dcomp_eval_df(psi_dpsi_temp, &Bdata->psi, r, phi, z);
 
@@ -371,7 +371,7 @@ a5err B_STS_eval_B_dB(real B_dB[12], real r, real phi, real z,
                       B_STS_data* Bdata) {
     a5err err = 0;
     int interperr = 0; /* If error happened during interpolation */
-    real B_dB_temp[10];
+    real B_dB_temp[4];
 
     interperr += interp3Dcomp_eval_df(B_dB_temp, &Bdata->B_r, r, phi, z);
 

--- a/src/E_field.c
+++ b/src/E_field.c
@@ -21,6 +21,7 @@
 #include "B_field.h"
 #include "Efield/E_TC.h"
 #include "Efield/E_1DS.h"
+#include "Efield/E_2DS.h"
 
 /**
  * @brief Free allocated resources
@@ -29,6 +30,9 @@
  */
 void E_field_free(E_field_data* data) {
     switch(data->type) {
+        case E_field_type_2DS:
+            E_2DS_free(&data->E2DS);
+            break;
         case E_field_type_1DS:
             E_1DS_free(&data->E1DS);
             break;
@@ -45,6 +49,9 @@ void E_field_free(E_field_data* data) {
  */
 void E_field_offload(E_field_data* data) {
     switch(data->type) {
+        case E_field_type_2DS:
+            E_2DS_offload(&data->E2DS);
+            break;
         case E_field_type_1DS:
             E_1DS_offload(&data->E1DS);
             break;
@@ -84,6 +91,10 @@ a5err E_field_eval_E(real E[3], real r, real phi, real z, real t,
     a5err err = 0;
 
     switch(Edata->type) {
+
+        case E_field_type_2DS:
+            err = E_2DS_eval_E(E, r, z, &(Edata->E2DS));
+            break;
 
         case E_field_type_1DS:
             err = E_1DS_eval_E(E, r, phi, z, &(Edata->E1DS), Bdata);

--- a/src/E_field.h
+++ b/src/E_field.h
@@ -14,6 +14,7 @@
 #include "B_field.h"
 #include "Efield/E_TC.h"
 #include "Efield/E_1DS.h"
+#include "Efield/E_2DS.h"
 
 /**
  * @brief Electric field types
@@ -23,8 +24,9 @@
  * field instance must have a corresponding type.
  */
 typedef enum E_field_type {
-    E_field_type_TC, /**< Trivial Cartesian electric field */
-    E_field_type_1DS /**< Spline-interpolated radial electric field */
+    E_field_type_TC,  /**< Trivial Cartesian electric field */
+    E_field_type_1DS, /**< Spline-interpolated radial electric field */
+    E_field_type_2DS  /**< Spline-interpolated radial electric field */
 } E_field_type;
 
 /**
@@ -37,6 +39,7 @@ typedef struct {
     E_field_type type; /**< Electric field type wrapped by this struct */
     E_TC_data ETC;     /**< TC field or NULL if not active             */
     E_1DS_data E1DS;   /**< 1DS field or NULL if not active            */
+    E_2DS_data E2DS;   /**< 1DS field or NULL if not active            */
 } E_field_data;
 
 void E_field_free(E_field_data* data);

--- a/src/Efield/E_2DS.c
+++ b/src/Efield/E_2DS.c
@@ -1,0 +1,58 @@
+/**
+ * @file E_2DS.c
+ * @brief 2D spline electric field
+ */
+#include <stdlib.h>
+#include "../ascot5.h"
+#include "../offload.h"
+#include "../print.h"
+#include "../error.h"
+#include "../spline/interp.h"
+#include "E_2DS.h"
+
+int E_2DS_init(E_2DS_data* data, int nr, real rmin, real rmax, int nz,
+    real zmin, real zmax, real* vpot) {
+
+    int err = 0;
+
+    /* Set up the splines */
+    err = interp2Dcomp_setup(&data->vpot, vpot, nr, nz, NATURALBC, NATURALBC,
+                             rmin, rmax, zmin, zmax);
+
+    if(err) {
+        print_err("Error: Failed to initialize splines.\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+
+void E_2DS_free(E_2DS_data* data) {
+    free(data->vpot.c);
+}
+
+
+void E_2DS_offload(E_2DS_data* data) {
+    GPU_MAP_TO_DEVICE(
+        data->vpot, data->vpot.c[0:data->vpot.n_x*data->vpot.n_y*NSIZE_COMP2D]
+    )
+}
+
+
+a5err E_2DS_eval_E(real E[3], real r, real z, E_2DS_data* Edata) {
+    real vdv[6];
+    int interperr = 0;
+    interperr += interp2Dcomp_eval_df(vdv, &Edata->vpot, r, z);
+
+    a5err err = 0;
+    if(interperr) {
+        err = error_raise( ERR_INPUT_EVALUATION, __LINE__, EF_E_2DS );
+    }
+
+    E[0] = -vdv[1];
+    E[1] = 0;
+    E[2] = -vdv[2];
+
+    return err;
+}

--- a/src/Efield/E_2DS.h
+++ b/src/Efield/E_2DS.h
@@ -1,0 +1,28 @@
+/**
+ * @file E_2DS.h
+ * @brief Header file for E_2DS.c
+ *
+ * Contains declaration of E_2DS_field_data struct.
+ */
+#ifndef E_2DS_H
+#define E_2DS_H
+#include "../offload.h"
+#include "../ascot5.h"
+#include "../error.h"
+#include "../spline/interp.h"
+
+/**
+ * @brief 2D spline electric field parameters
+ */
+typedef struct {
+    interp2D_data vpot;  /**< Interpolation struct for the 2D potential */
+} E_2DS_data;
+
+int E_2DS_init(E_2DS_data* data, int nr, real rmin, real rmax, int nz,
+    real zmin, real zmax, real* vpot);
+void E_2DS_free(E_2DS_data* data);
+void E_2DS_offload(E_2DS_data* data);
+GPU_DECLARE_TARGET_SIMD_UNIFORM(Edata)
+a5err E_2DS_eval_E(real E[3], real r, real z, E_2DS_data* Edata);
+DECLARE_TARGET_END
+#endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ CFLAGS+=-Wall -fPIC -std=c11 -D_XOPEN_SOURCE=700 $(DEFINES) $(FLAGS)
 ifeq ($(DEBUG),1)
 	CFLAGS+=-g -fsanitize=address,undefined
 else
-	CFLAGS+=-O2
+	CFLAGS+=-g
 endif
 
 ifeq ($(CC), $(filter $(CC), h5cc h5pcc))

--- a/src/afsi.c
+++ b/src/afsi.c
@@ -526,6 +526,10 @@ void afsi_sample_thermal_2d(sim_data* sim, int ispecies, real mass, int nsample,
         *density = 0.0;
         return;
     }
+
+    real vflow;
+    plasma_eval_flow(&vflow, rho, r, phi, z, time, &sim->plasma_data);
+
     *density = ni;
     for(int i = 0; i < nsample; i++) {
         real r1, r2, r3, r4, E;
@@ -537,6 +541,6 @@ void afsi_sample_thermal_2d(sim_data* sim, int ispecies, real mass, int nsample,
 
         r4 = 1.0 - 2 * random_uniform(&rdata);
         pperp[i] = sqrt( ( 1 - r4*r4 ) * 2 * E * mass);
-        ppara[i] = r4 * sqrt(2 * E * mass);
+        ppara[i] = r4 * sqrt(2 * E * mass) - vflow * mass;
     }
 }

--- a/src/asigma/asigma_loc.c
+++ b/src/asigma/asigma_loc.c
@@ -42,6 +42,7 @@ int asigma_loc_init(asigma_loc_data* data, int nreac,
     data->sigma = (interp1D_data*) malloc( nreac * sizeof(interp1D_data) );
     data->sigmav = (interp2D_data*) malloc( nreac * sizeof(interp2D_data) );
     data->BMSsigmav = (interp3D_data*) malloc( nreac * sizeof(interp3D_data) );
+    real* pos = sigma;
     for(int i_reac = 0; i_reac < nreac; i_reac++) {
         data->z_1[i_reac] = z1[i_reac];
         data->a_1[i_reac] = a1[i_reac];
@@ -52,7 +53,6 @@ int asigma_loc_init(asigma_loc_data* data, int nreac,
         /* Initialize spline struct according to dimensionality of
            reaction data (and mark reaction availability) */
         int dim = (ne[i_reac] > 1) + (nn[i_reac] > 1) + (nT[i_reac] > 1);
-        real* pos = sigma;
         switch(dim) {
             case 1:
                 err = interp1Dcomp_setup(&data->sigma[i_reac], pos,

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -243,7 +243,6 @@ void bbnbi_trace_markers(particle_queue *pq, sim_data* sim) {
                 /* These are needed later */
                 real pnorm = math_normc(p.p_r[i], p.p_phi[i], p.p_z[i]);
                 real gamma = physlib_gamma_pnorm(p.mass[i], pnorm);
-                real ekin  = physlib_Ekin_pnorm(p.mass[i], pnorm);
 
                 /* Advance ballistic trajectory by converting momentum to
                  * cartesian coordinates */
@@ -297,6 +296,26 @@ void bbnbi_trace_markers(particle_queue *pq, sim_data* sim) {
                         pls_dens, pls_temp, rho[0], p.r[i], p.phi[i], p.z[i],
                         p.time[i], &sim->plasma_data);
                 }
+
+                /* Compute kinetic energy in plasma frame */
+                real vflow = 0;
+                if(!err) {
+                    err = plasma_eval_flow(
+                        &vflow, p.rho[i], p.r[i], p.phi[i], p.z[i], p.time[i],
+                        &sim->plasma_data);
+                }
+                real vplasma[3];
+                real bnorm = math_normc(p.B_r[i], p.B_phi[i], p.B_z[i]);
+                vplasma[0] = ( p.p_r[i] / ( gamma * p.mass[i] )
+                    - vflow * p.B_r[i] / bnorm );
+                vplasma[1] = ( p.p_phi[i] / ( gamma * p.mass[i] )
+                    - vflow * p.B_phi[i] / bnorm );
+                vplasma[2] = p.p_z[i] / ( gamma * p.mass[i] )
+                    - vflow * p.B_z[i] / bnorm;
+
+                real vnorm = math_norm(vplasma);
+                pnorm = physlib_pnorm_vnorm(p.mass[i], vnorm);
+                real ekin  = physlib_Ekin_pnorm(p.mass[i], pnorm);
 
                 /* Calculate ionization rate */
                 real rate = 0.0;

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -163,7 +163,7 @@ void bbnbi_inject_markers(particle_state* p, int nprt, int ngenerated, real t0,
             math_xyz2rpz(xyz, rpz);
             err = B_field_eval_psi(&psi, rpz[0], rpz[1], rpz[2], time,
                                    &sim->B_data);
-            if(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2] > 1e3) {
+            if(sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]) > 1e3) {
                 break;
             }
         }

--- a/src/bbnbi5.c
+++ b/src/bbnbi5.c
@@ -58,7 +58,7 @@ void bbnbi_simulate(
 
     /* Initialize input data */
     simulate_init(sim);
-    random_init(&sim->random_data, time(NULL));
+    random_init(sim->random_data, time(NULL));
 
     /* Calculate total NBI power so that we can distribute markers along
      * the injectors according to their power */
@@ -143,11 +143,11 @@ void bbnbi_inject_markers(particle_state* p, int nprt, int ngenerated, real t0,
      * other physics) until they enter the plasma for the first time.     */
     #pragma omp parallel for
     for(int i = 0; i < nprt; i++) {
-        real time = t0 + random_uniform(&sim->random_data) * (t1-t0);
+        real time = t0 + random_uniform(sim->random_data) * (t1-t0);
 
         /* Assign initial phase-space coordinates for this marker */
         real xyz[3], vxyz[3], rpz[3], vhat[3];
-        nbi_inject(xyz, vxyz, inj, &sim->random_data);
+        nbi_inject(xyz, vxyz, inj, sim->random_data);
         math_xyz2rpz(xyz, rpz);
         math_unit(vxyz, vhat);
 
@@ -223,7 +223,7 @@ void bbnbi_trace_markers(particle_queue *pq, sim_data* sim) {
         p.id[i] = -1;
         p.running[i] = 0;
         hin[i] = 1e-10;
-        threshold[i] = random_uniform(&sim->random_data);
+        threshold[i] = random_uniform(sim->random_data);
         remaining[i] = 1.0;
         shinethrough[i] = 0;
     }
@@ -357,7 +357,7 @@ void bbnbi_trace_markers(particle_queue *pq, sim_data* sim) {
                 p.time[i] += p.mileage[i];
 
                 /* Reset these for the next marker */
-                threshold[i] = random_uniform(&sim->random_data);
+                threshold[i] = random_uniform(sim->random_data);
                 remaining[i] = 1.0;
                 shinethrough[i] = 0;
 

--- a/src/boozer.h
+++ b/src/boozer.h
@@ -31,7 +31,7 @@ int boozer_init(boozer_data* data, int npsi, real psi_min, real psi_max,
                 int nrzs, real* rs, real* zs);
 void boozer_free(boozer_data* data);
 void boozer_offload(boozer_data* data);
-DECLARE_TARGET_SIMD_UNIFORM(Bdata, boozerdata)
+GPU_DECLARE_TARGET_SIMD_UNIFORM(Bdata, boozerdata)
 a5err boozer_eval_psithetazeta(real psithetazeta[12], int* isinside, real r,
                                real phi, real z, B_field_data* Bdata,
                                boozer_data* boozerdata);

--- a/src/boschhale.c
+++ b/src/boschhale.c
@@ -79,6 +79,8 @@ void boschhale_reaction(
 /**
  * @brief Estimate cross-section for a given fusion reaction.
  *
+ * See: Bosch and Hale, 1992, Nuclear Fusion. Vol. 32, No.4. Section 4.2
+ *
  * @param reaction reaction for which the cross-section is estimated.
  * @param E ion energy [J].
  *
@@ -93,7 +95,7 @@ real boschhale_sigma(Reaction reaction, real E) {
     switch(reaction) {
 
     case DT_He4n:
-        if(E <= 530) {
+        if(E <= 550) {
             BG = 34.3827;
             A[0] = 6.927e4;
             A[1] = 7.454e8;
@@ -202,6 +204,7 @@ real boschhale_sigma(Reaction reaction, real E) {
         return 0;
     }
 
+    /* "With E in keV, the sigma is given in millibarns", hence 1e-31 */
     real sigma = S / (E * exp(BG / sqrt(E))) * 1e-31;
 
     return sigma;
@@ -210,10 +213,14 @@ real boschhale_sigma(Reaction reaction, real E) {
 /**
  * @brief Estimate reactivity for a given fusion reaction.
  *
+ * For two Maxwellian distributions with temperature Ti.
+ *
+ * See: Bosch and Hale, 1992, Nuclear Fusion. Vol. 32, No.4. Section 5.2
+ *
  * @param reaction reaction for which the reactivity is estimated.
  * @param Ti ion temperature [keV].
  *
- * @return reactivity.
+ * @return reactivity [m^3/s].
  */
 real boschhale_sigmav(Reaction reaction, real Ti) {
 

--- a/src/diag/diag_orb.c
+++ b/src/diag/diag_orb.c
@@ -398,6 +398,7 @@ void diag_orb_update_fo(diag_orb_data* data, particle_simd_fo* p_f,
                         }
                         data->mrk_pnt[imrk]      = ipoint;
                         data->mrk_recorded[imrk] = p_f->mileage[i];
+                        data->simmode[idx]= DIAG_ORB_FO;
                     }
                 }
             }
@@ -605,6 +606,7 @@ void diag_orb_update_gc(diag_orb_data* data, particle_simd_gc* p_f,
                         }
                         data->mrk_pnt[imrk]      = ipoint;
                         data->mrk_recorded[imrk] = p_f->mileage[i];
+                        data->simmode[idx]= DIAG_ORB_GC;
                     }
                 }
             }
@@ -782,7 +784,7 @@ void diag_orb_update_ml(diag_orb_data* data, particle_simd_ml* p_f,
                         if(ipoint == data->Npnt) {
                             ipoint = 0;
                         }
-
+                        data->simmode[idx]= DIAG_ORB_ML;
                         data->mrk_pnt[imrk]      = ipoint;
                         data->mrk_recorded[imrk] = p_f->mileage[i];
                     }

--- a/src/diag/diag_transcoef.c
+++ b/src/diag/diag_transcoef.c
@@ -95,8 +95,8 @@ void diag_transcoef_update_fo(diag_transcoef_data* data,
  */
 void diag_transcoef_update_gc(diag_transcoef_data* data,
                               particle_simd_gc* p_f, particle_simd_gc* p_i) {
-    #pragma omp simd
-    for(int i=0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i=0; i < p_f->n_mrk; i++) {
         real pitchsign = 1 - 2*(p_f->ppar[i] < 0);
         diag_transcoef_record(
             data, p_f->index[i], p_f->id[i], p_f->rho[i], p_f->r[i], pitchsign,
@@ -105,7 +105,8 @@ void diag_transcoef_update_gc(diag_transcoef_data* data,
 
 
     /* If marker simulation was ended, process and clean the data */
-    for(int i=0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i=0; i < p_f->n_mrk; i++) {
 
         /* Mask dummy markers and those which are running */
         if( p_f->id[i] < 1 || p_f->running[i] > 0 ) {

--- a/src/diag/dist_5D.c
+++ b/src/diag/dist_5D.c
@@ -193,76 +193,54 @@ void dist_5D_update_fo(dist_5D_data* dist, particle_simd_fo* p_f,
  */
 void dist_5D_update_gc(dist_5D_data* dist, particle_simd_gc* p_f,
                        particle_simd_gc* p_i) {
-    real phi[NSIMD];
-    real pperp[NSIMD];
 
-    int i_r[NSIMD];
-    int i_phi[NSIMD];
-    int i_z[NSIMD];
-    int i_ppara[NSIMD];
-    int i_pperp[NSIMD];
-    int i_time[NSIMD];
-    int i_q[NSIMD];
-
-    int ok[NSIMD];
-    real weight[NSIMD];
-
-    #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p_f->n_mrk; i++) {
         if(p_f->running[i]) {
-            i_r[i] = floor((p_f->r[i] - dist->min_r)
+            int i_r = floor((p_f->r[i] - dist->min_r)
                      / ((dist->max_r - dist->min_r)/dist->n_r));
 
-            phi[i] = fmod(p_f->phi[i], 2*CONST_PI);
-            if(phi[i] < 0) {
-                phi[i] = phi[i] + 2*CONST_PI;
+            real phi = fmod(p_f->phi[i], 2*CONST_PI);
+            if(phi < 0) {
+                phi = phi + 2*CONST_PI;
             }
-            i_phi[i] = floor((phi[i] - dist->min_phi)
+            int i_phi = floor((phi - dist->min_phi)
                        / ((dist->max_phi - dist->min_phi)/dist->n_phi));
 
-            i_z[i] = floor((p_f->z[i] - dist->min_z)
+            int i_z = floor((p_f->z[i] - dist->min_z)
                     / ((dist->max_z - dist->min_z) / dist->n_z));
 
-            i_ppara[i] = floor((p_f->ppar[i] - dist->min_ppara)
+            int i_ppara = floor((p_f->ppar[i] - dist->min_ppara)
                        / ((dist->max_ppara - dist->min_ppara) / dist->n_ppara));
 
-            pperp[i] = sqrt(2 * sqrt(  p_f->B_r[i]   * p_f->B_r[i]
+            real pperp = sqrt(2 * sqrt(  p_f->B_r[i]   * p_f->B_r[i]
                                      + p_f->B_phi[i] * p_f->B_phi[i]
                                      + p_f->B_z[i]   * p_f->B_z[i] )
                             * p_f->mu[i] * p_f->mass[i]);
-            i_pperp[i] = floor((pperp[i] - dist->min_pperp)
+            int i_pperp = floor((pperp - dist->min_pperp)
                        / ((dist->max_pperp - dist->min_pperp) / dist->n_pperp));
 
-            i_time[i] = floor((p_f->time[i] - dist->min_time)
+            int i_time = floor((p_f->time[i] - dist->min_time)
                           / ((dist->max_time - dist->min_time) / dist->n_time));
 
-            i_q[i] = floor((p_f->charge[i]/CONST_E - dist->min_q)
+            int i_q = floor((p_f->charge[i]/CONST_E - dist->min_q)
                            / ((dist->max_q - dist->min_q) / dist->n_q));
 
-            if(i_r[i]     >= 0  &&  i_r[i]     <= dist->n_r - 1      &&
-               i_phi[i]   >= 0  &&  i_phi[i]   <= dist->n_phi - 1    &&
-               i_z[i]     >= 0  &&  i_z[i]     <= dist->n_z - 1      &&
-               i_ppara[i] >= 0  &&  i_ppara[i] <= dist->n_ppara - 1  &&
-               i_pperp[i] >= 0  &&  i_pperp[i] <= dist->n_pperp - 1  &&
-               i_time[i]  >= 0  &&  i_time[i]  <= dist->n_time - 1   &&
-               i_q[i]     >= 0  &&  i_q[i]     <= dist->n_q - 1        ) {
-                ok[i] = 1;
-                weight[i] = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
-            }
-            else {
-                ok[i] = 0;
-            }
-        }
-    }
-
-    for(int i = 0; i < NSIMD; i++) {
-        if(p_f->running[i] && ok[i]) {
-            size_t index = dist_5D_index(
-                i_r[i], i_phi[i], i_z[i], i_ppara[i], i_pperp[i], i_time[i],
-                i_q[i], dist->step_6, dist->step_5, dist->step_4,
+            if(i_r     >= 0  &&  i_r     <= dist->n_r - 1      &&
+               i_phi   >= 0  &&  i_phi   <= dist->n_phi - 1    &&
+               i_z     >= 0  &&  i_z     <= dist->n_z - 1      &&
+               i_ppara >= 0  &&  i_ppara <= dist->n_ppara - 1  &&
+               i_pperp >= 0  &&  i_pperp <= dist->n_pperp - 1  &&
+               i_time  >= 0  &&  i_time  <= dist->n_time - 1   &&
+               i_q     >= 0  &&  i_q     <= dist->n_q - 1        ) {
+	       real weight = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
+	       size_t index = dist_5D_index(
+                i_r, i_phi, i_z, i_ppara, i_pperp, i_time,
+                i_q, dist->step_6, dist->step_5, dist->step_4,
                 dist->step_3, dist->step_2, dist->step_1);
-            #pragma omp atomic
-            dist->histogram[index] += weight[i];
+	        GPU_ATOMIC
+                dist->histogram[index] += weight;
+            }
         }
     }
 }

--- a/src/diag/dist_com.c
+++ b/src/diag/dist_com.c
@@ -156,15 +156,9 @@ void dist_COM_update_fo(dist_COM_data* dist, B_field_data* Bdata,
  */
 void dist_COM_update_gc(dist_COM_data* dist, B_field_data* Bdata,
                         particle_simd_gc* p_f, particle_simd_gc* p_i) {
-    int i_mu[NSIMD];
-    int i_Ekin[NSIMD];
-    int i_Ptor[NSIMD];
 
-    int ok[NSIMD];
-    real weight[NSIMD];
-
-    #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p_f->n_mrk; i++) {
         if(p_f->running[i]) {
             real Ekin, Ptor, B, psi;
 
@@ -172,37 +166,28 @@ void dist_COM_update_gc(dist_COM_data* dist, B_field_data* Bdata,
                              p_f->time[i], Bdata);
 
             B = math_normc(p_f->B_r[i], p_f->B_phi[i], p_f->B_z[i]);
-            i_mu[i] = floor((p_f->mu[i] - dist->min_mu)
+            int i_mu = floor((p_f->mu[i] - dist->min_mu)
                             / ((dist->max_mu - dist->min_mu)/dist->n_mu));
 
             Ekin = physlib_Ekin_ppar(p_f->mass[i], p_f->mu[i], p_f->ppar[i], B);
 
-            i_Ekin[i] = floor((Ekin - dist->min_Ekin)
+            int i_Ekin = floor((Ekin - dist->min_Ekin)
                          / ((dist->max_Ekin - dist->min_Ekin) / dist->n_Ekin));
             Ptor = phys_ptoroid_gc(p_f->charge[i], p_f->r[i], p_f->ppar[i], psi,
                                    B, p_f->B_phi[i]);
 
-            i_Ptor[i] = floor((Ptor - dist->min_Ptor)
+            int i_Ptor = floor((Ptor - dist->min_Ptor)
                          / ((dist->max_Ptor - dist->min_Ptor)/dist->n_Ptor));
 
-            if(i_mu[i]   >= 0 && i_mu[i]   <= dist->n_mu - 1   &&
-               i_Ekin[i] >= 0 && i_Ekin[i] <= dist->n_Ekin - 1 &&
-               i_Ptor[i] >= 0 && i_Ptor[i] <= dist->n_Ptor - 1 ) {
-                ok[i] = 1;
-                weight[i] = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
-            }
-            else {
-                ok[i] = 0;
-            }
-        }
-    }
-
-    for(int i = 0; i < NSIMD; i++) {
-        if(p_f->running[i] && ok[i]) {
-            size_t index = dist_COM_index(i_mu[i], i_Ekin[i], i_Ptor[i],
+            if(i_mu   >= 0 && i_mu   <= dist->n_mu - 1   &&
+               i_Ekin >= 0 && i_Ekin <= dist->n_Ekin - 1 &&
+               i_Ptor >= 0 && i_Ptor <= dist->n_Ptor - 1 ) {
+                real weight = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
+		size_t index = dist_COM_index(i_mu, i_Ekin, i_Ptor,
                                           dist->step_2, dist->step_1);
-            #pragma omp atomic
-            dist->histogram[index] += weight[i];
+		GPU_ATOMIC
+		dist->histogram[index] += weight;
+            }
         }
     }
 }

--- a/src/diag/dist_rho5D.c
+++ b/src/diag/dist_rho5D.c
@@ -200,84 +200,61 @@ void dist_rho5D_update_fo(dist_rho5D_data* dist, particle_simd_fo* p_f,
  */
 void dist_rho5D_update_gc(dist_rho5D_data* dist, particle_simd_gc* p_f,
                           particle_simd_gc* p_i) {
-    real phi[NSIMD];
-    real theta[NSIMD];
-    real pperp[NSIMD];
 
-    int i_rho[NSIMD];
-    int i_phi[NSIMD];
-    int i_theta[NSIMD];
-    int i_ppara[NSIMD];
-    int i_pperp[NSIMD];
-    int i_time[NSIMD];
-    int i_q[NSIMD];
-
-    int ok[NSIMD];
-    real weight[NSIMD];
-
-    #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p_f->n_mrk; i++) {
         if(p_f->running[i]) {
 
-            i_rho[i] = floor((p_f->rho[i] - dist->min_rho)
+            int i_rho = floor((p_f->rho[i] - dist->min_rho)
                              / ((dist->max_rho - dist->min_rho)/dist->n_rho));
 
-            phi[i] = fmod(p_f->phi[i], 2*CONST_PI);
-            if(phi[i] < 0) {
-                phi[i] = phi[i] + 2*CONST_PI;
+            real phi = fmod(p_f->phi[i], 2*CONST_PI);
+            if(phi < 0) {
+                phi = phi + 2*CONST_PI;
             }
-            i_phi[i] = floor((phi[i] - dist->min_phi)
+            int i_phi = floor((phi - dist->min_phi)
                              / ((dist->max_phi - dist->min_phi)/dist->n_phi));
 
-            theta[i] = fmod(p_f->theta[i], 2*CONST_PI);
-            if(theta[i] < 0) {
-                theta[i] = theta[i] + 2*CONST_PI;
+            real theta = fmod(p_f->theta[i], 2*CONST_PI);
+            if(theta < 0) {
+                theta = theta + 2*CONST_PI;
             }
-            i_theta[i] = floor((theta[i] - dist->min_theta)
+            int i_theta = floor((theta - dist->min_theta)
                                / ((dist->max_theta - dist->min_theta)
                                   / dist->n_theta));
 
-            i_ppara[i] = floor((p_f->ppar[i] - dist->min_ppara)
+            int i_ppara = floor((p_f->ppar[i] - dist->min_ppara)
                        / ((dist->max_ppara - dist->min_ppara) / dist->n_ppara));
 
-            pperp[i] = sqrt(2 * sqrt(  p_f->B_r[i]   * p_f->B_r[i]
+            real pperp = sqrt(2 * sqrt(  p_f->B_r[i]   * p_f->B_r[i]
                                      + p_f->B_phi[i] * p_f->B_phi[i]
                                      + p_f->B_z[i]   * p_f->B_z[i] )
                             * p_f->mu[i] * p_f->mass[i]);
-            i_pperp[i] = floor((pperp[i] - dist->min_pperp)
+            int i_pperp = floor((pperp - dist->min_pperp)
                                / ((dist->max_pperp - dist->min_pperp)
                                   / dist->n_pperp));
 
-            i_time[i] = floor((p_f->time[i] - dist->min_time)
+            int i_time = floor((p_f->time[i] - dist->min_time)
                           / ((dist->max_time - dist->min_time) / dist->n_time));
 
-            i_q[i] = floor((p_f->charge[i]/CONST_E - dist->min_q)
+            int i_q = floor((p_f->charge[i]/CONST_E - dist->min_q)
                            / ((dist->max_q - dist->min_q) / dist->n_q));
 
-            if(i_rho[i]   >= 0 && i_rho[i]   <= dist->n_rho - 1   &&
-               i_phi[i]   >= 0 && i_phi[i]   <= dist->n_phi - 1   &&
-               i_theta[i] >= 0 && i_theta[i] <= dist->n_theta - 1 &&
-               i_ppara[i] >= 0 && i_ppara[i] <= dist->n_ppara - 1 &&
-               i_pperp[i] >= 0 && i_pperp[i] <= dist->n_pperp - 1 &&
-               i_time[i]  >= 0 && i_time[i]  <= dist->n_time - 1  &&
-               i_q[i]     >= 0 && i_q[i]     <= dist->n_q - 1       ) {
-                ok[i] = 1;
-                weight[i] = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
-            }
-            else {
-                ok[i] = 0;
-            }
-        }
-    }
-
-    for(int i = 0; i < NSIMD; i++) {
-        if(p_f->running[i] && ok[i]) {
-            size_t index = dist_rho5D_index(
-                i_rho[i], i_theta[i], i_phi[i], i_ppara[i], i_pperp[i],
-                i_time[i], i_q[i], dist->step_6, dist->step_5, dist->step_4,
+            if(i_rho   >= 0 && i_rho   <= dist->n_rho - 1   &&
+               i_phi   >= 0 && i_phi   <= dist->n_phi - 1   &&
+               i_theta >= 0 && i_theta <= dist->n_theta - 1 &&
+               i_ppara >= 0 && i_ppara <= dist->n_ppara - 1 &&
+               i_pperp >= 0 && i_pperp <= dist->n_pperp - 1 &&
+               i_time  >= 0 && i_time  <= dist->n_time - 1  &&
+               i_q     >= 0 && i_q     <= dist->n_q - 1       ) {
+	      real weight = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
+	      size_t index = dist_rho5D_index(
+                i_rho, i_theta, i_phi, i_ppara, i_pperp,
+                i_time, i_q, dist->step_6, dist->step_5, dist->step_4,
                 dist->step_3, dist->step_2, dist->step_1);
-            #pragma omp atomic
-            dist->histogram[index] += weight[i];
+	      GPU_ATOMIC
+	      dist->histogram[index] += weight;
+            }
         }
     }
 }

--- a/src/diag/dist_rho6D.c
+++ b/src/diag/dist_rho6D.c
@@ -191,23 +191,9 @@ void dist_rho6D_update_fo(dist_rho6D_data* dist, particle_simd_fo* p_f,
  */
 void dist_rho6D_update_gc(dist_rho6D_data* dist, particle_simd_gc* p_f,
                           particle_simd_gc* p_i) {
-    real phi[NSIMD];
-    real theta[NSIMD];
 
-    int i_rho[NSIMD];
-    int i_theta[NSIMD];
-    int i_phi[NSIMD];
-    int i_pr[NSIMD];
-    int i_pphi[NSIMD];
-    int i_pz[NSIMD];
-    int i_time[NSIMD];
-    int i_q[NSIMD];
-
-    int ok[NSIMD];
-    real weight[NSIMD];
-
-    #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p_f->n_mrk; i++) {
         if(p_f->running[i]) {
 
             real pr, pphi, pz;
@@ -228,65 +214,56 @@ void dist_rho6D_update_gc(dist_rho6D_data* dist, particle_simd_gc* p_f,
                                             p_f->mu[i], p_f->zeta[i],
                                             &pr, &pphi, &pz);
 
-            i_rho[i] = floor((p_f->rho[i] - dist->min_rho)
+            int i_rho = floor((p_f->rho[i] - dist->min_rho)
                              / ((dist->max_rho - dist->min_rho)/dist->n_rho));
 
-            phi[i] = fmod(p_f->phi[i], 2*CONST_PI);
-            if(phi[i] < 0) {
-                phi[i] = phi[i] + 2*CONST_PI;
+            real phi = fmod(p_f->phi[i], 2*CONST_PI);
+            if(phi < 0) {
+                phi = phi + 2*CONST_PI;
             }
-            i_phi[i] = floor((phi[i] - dist->min_phi)
+            int i_phi = floor((phi - dist->min_phi)
                              / ((dist->max_phi - dist->min_phi)/dist->n_phi));
 
-            theta[i] = fmod(p_f->theta[i], 2*CONST_PI);
-            if(theta[i] < 0) {
-                theta[i] = theta[i] + 2*CONST_PI;
+            real theta = fmod(p_f->theta[i], 2*CONST_PI);
+            if(theta < 0) {
+                theta = theta + 2*CONST_PI;
             }
-            i_theta[i] = floor((theta[i] - dist->min_theta)
+            int i_theta = floor((theta - dist->min_theta)
                              / ((dist->max_theta - dist->min_theta)
                                 / dist->n_theta));
 
-            i_pr[i] = floor((pr - dist->min_pr)
+            int i_pr = floor((pr - dist->min_pr)
                             / ((dist->max_pr - dist->min_pr) / dist->n_pr));
 
-            i_pphi[i] = floor((pphi - dist->min_pphi)
+            int i_pphi = floor((pphi - dist->min_pphi)
                               / ((dist->max_pphi - dist->min_pphi)
                                  / dist->n_pphi));
 
-            i_pz[i] = floor((pz - dist->min_pz)
+            int i_pz = floor((pz - dist->min_pz)
                             / ((dist->max_pz - dist->min_pz) / dist->n_pz));
 
-            i_time[i] = floor((p_f->time[i] - dist->min_time)
+            int i_time = floor((p_f->time[i] - dist->min_time)
                           / ((dist->max_time - dist->min_time) / dist->n_time));
 
-            i_q[i] = floor((p_f->charge[i]/CONST_E - dist->min_q)
+            int i_q = floor((p_f->charge[i]/CONST_E - dist->min_q)
                            / ((dist->max_q - dist->min_q) / dist->n_q));
 
-            if(i_rho[i]  >= 0 && i_rho[i]  <= dist->n_rho - 1  &&
-               i_theta[i]  >= 0 && i_theta[i]  <= dist->n_theta -1   &&
-               i_phi[i]  >= 0 && i_phi[i]  <= dist->n_phi - 1  &&
-               i_pr[i]   >= 0 && i_pr[i]   <= dist->n_pr - 1   &&
-               i_pphi[i] >= 0 && i_pphi[i] <= dist->n_pphi - 1 &&
-               i_pz[i]   >= 0 && i_pz[i]   <= dist->n_pz - 1   &&
-               i_time[i] >= 0 && i_time[i] <= dist->n_time - 1 &&
-               i_q[i]    >= 0 && i_q[i]    <= dist->n_q - 1      ) {
-                ok[i] = 1;
-                weight[i] = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
-            }
-            else {
-                ok[i] = 0;
-            }
-        }
-    }
-
-    for(int i = 0; i < NSIMD; i++) {
-        if(p_f->running[i] && ok[i]) {
-            size_t index = dist_rho6D_index(
-                i_rho[i], i_theta[i], i_phi[i], i_pr[i], i_pphi[i], i_pz[i],
-                i_time[i], i_q[i], dist->step_7, dist->step_6, dist->step_5,
+            if(i_rho  >= 0 && i_rho  <= dist->n_rho - 1  &&
+               i_theta  >= 0 && i_theta  <= dist->n_theta -1   &&
+               i_phi  >= 0 && i_phi  <= dist->n_phi - 1  &&
+               i_pr   >= 0 && i_pr   <= dist->n_pr - 1   &&
+               i_pphi >= 0 && i_pphi <= dist->n_pphi - 1 &&
+               i_pz   >= 0 && i_pz   <= dist->n_pz - 1   &&
+               i_time >= 0 && i_time <= dist->n_time - 1 &&
+               i_q    >= 0 && i_q    <= dist->n_q - 1      ) {
+	      real weight = p_f->weight[i] * (p_f->time[i] - p_i->time[i]);
+	      size_t index = dist_rho6D_index(
+                i_rho, i_theta, i_phi, i_pr, i_pphi, i_pz,
+                i_time, i_q, dist->step_7, dist->step_6, dist->step_5,
                 dist->step_4, dist->step_3, dist->step_2, dist->step_1);
-            #pragma omp atomic
-            dist->histogram[index] += weight[i];
+	      GPU_ATOMIC
+	      dist->histogram[index] += weight;
+            }
         }
     }
 }

--- a/src/endcond.c
+++ b/src/endcond.c
@@ -273,8 +273,8 @@ void endcond_check_gc(particle_simd_gc* p_f, particle_simd_gc* p_i,
     int active_tormax    = sim->endcond_active & endcond_tormax;
     int active_cpumax    = sim->endcond_active & endcond_cpumax;
 
-    #pragma omp simd
-    for(i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(i = 0; i < p_f->n_mrk; i++) {
         if(p_f->running[i]) {
             /* Update bounces if pitch changed sign */
             if( p_i->ppar[i] * p_f->ppar[i] < 0 ) {

--- a/src/endcond.c
+++ b/src/endcond.c
@@ -150,22 +150,37 @@ void endcond_check_fo(particle_simd_fo* p_f, particle_simd_fo* p_i,
             /* Evaluate marker energy, and check if it is below the minimum
              * energy limit or local thermal energy limit */
             if(active_emin || active_therm) {
-                real pnorm = math_normc(
-                    p_f->p_r[i], p_f->p_phi[i], p_f->p_z[i]);
-                real ekin = physlib_Ekin_pnorm(p_f->mass[i], pnorm);
 
-                real Ti;
+                real Ti, vflow;
                 a5err errflag =
                     plasma_eval_temp(&Ti, p_f->rho[i], p_f->r[i], p_f->phi[i],
                                      p_f->z[i], p_f->time[i], 1,
                                      &sim->plasma_data);
+                plasma_eval_flow(&vflow, p_f->rho[i], p_f->r[i], p_f->phi[i],
+                                 p_f->z[i], p_f->time[i], &sim->plasma_data);
 
                 /* Error handling */
                 if(errflag) {
                     p_f->err[i]     = errflag;
                     p_f->running[i] = 0;
                     Ti = 0;
+                    vflow = 0;
                 }
+                real pnorm = math_normc(
+                    p_f->p_r[i], p_f->p_phi[i], p_f->p_z[i]);
+                real gamma = physlib_gamma_pnorm(p_f->mass[i], pnorm);
+                real vplasma[3];
+                real bnorm = math_normc(p_f->B_r[i], p_f->B_phi[i], p_f->B_z[i]);
+                vplasma[0] = ( p_f->p_r[i] / ( gamma * p_f->mass[i] )
+                    - vflow * p_f->B_r[i] / bnorm );
+                vplasma[1] = ( p_f->p_phi[i] / ( gamma * p_f->mass[i] )
+                    - vflow * p_f->B_phi[i] / bnorm );
+                vplasma[2] = p_f->p_z[i] / ( gamma * p_f->mass[i] )
+                    - vflow * p_f->B_z[i] / bnorm;
+
+                real vnorm = math_norm(vplasma);
+                pnorm = physlib_pnorm_vnorm(p_f->mass[i], vnorm);
+                real ekin  = physlib_Ekin_pnorm(p_f->mass[i], pnorm);
 
                 if( active_emin && (ekin < sim->endcond_min_ekin) ) {
                     p_f->endcond[i] |= endcond_emin;
@@ -328,22 +343,33 @@ void endcond_check_gc(particle_simd_gc* p_f, particle_simd_gc* p_i,
             if(active_emin || active_therm) {
                 real Bnorm = math_normc(
                     p_f->B_r[i], p_f->B_phi[i], p_f->B_z[i]);
-                real ekin = physlib_Ekin_ppar(p_f->mass[i], p_f->mu[i],
-                                              p_f->ppar[i], Bnorm);
 
 
-                real Ti;
-                a5err  errflag =
+                real Ti, vflow;
+                a5err errflag =
                     plasma_eval_temp(&Ti, p_f->rho[i], p_f->r[i], p_f->phi[i],
                                      p_f->z[i], p_f->time[i], 1,
                                      &sim->plasma_data);
+                plasma_eval_flow(&vflow, p_f->rho[i], p_f->r[i], p_f->phi[i],
+                                 p_f->z[i], p_f->time[i], &sim->plasma_data);
 
                 /* Error handling */
                 if(errflag) {
                     p_f->err[i]     = errflag;
                     p_f->running[i] = 0;
                     Ti = 0;
+                    vflow = 0;
                 }
+                real pnorm = physlib_gc_p(
+                    p_f->mass[i], p_f->mu[i], p_f->ppar[i], Bnorm);
+                real xi = physlib_gc_xi(
+                    p_f->mass[i], p_f->mu[i], p_f->ppar[i], Bnorm);
+                real vnorm = physlib_vnorm_pnorm(p_f->mass[i], pnorm);
+                real vpar = xi * vnorm;
+                real vperp2 = (1 - xi * xi) * vnorm * vnorm;
+                vnorm = sqrt((vpar - vflow) * (vpar - vflow) + vperp2);
+                real gamma = physlib_gamma_vnorm(vnorm);
+                real ekin = physlib_Ekin_gamma(p_f->mass[i], gamma);
 
                 if(active_emin && (ekin < sim->endcond_min_ekin) ) {
                     p_f->endcond[i] |= endcond_emin;

--- a/src/error.c
+++ b/src/error.c
@@ -151,6 +151,10 @@ void error_parse2str(a5err err, char* msg, char* line, char* file) {
             sprintf(file, "plasma_1D.c");
             break;
 
+        case EF_PLASMA_2D:
+            sprintf(file, "plasma_2D.c");
+            break;
+
         case EF_PLASMA_1DS:
             sprintf(file, "plasma_1DS.c");
             break;

--- a/src/error.c
+++ b/src/error.c
@@ -227,6 +227,10 @@ void error_parse2str(a5err err, char* msg, char* line, char* file) {
             sprintf(file, "asigma_loc.c");
             break;
 
+        case EF_E_2DS:
+            sprintf(file, "E_2DS.c");
+            break;
+
         default:
             sprintf(file, "unknown file");
             break;

--- a/src/error.h
+++ b/src/error.h
@@ -37,7 +37,7 @@ typedef enum error_file {
     EF_B_2DS             =  12, /**< Error is from B_2DS.c                    */
     EF_B_STS             =  13, /**< Error is from B_STS.c                    */
     EF_B_GS              =  14, /**< Error is from B_GS.c                     */
-    EF_PLASMA_1D         =  15, /**< Error is from plasma_1DS.c               */
+    EF_PLASMA_1D         =  15, /**< Error is from plasma_1D.c                */
     EF_PLASMA_1DS        =  16, /**< Error is from plasma_1DS.c               */
     EF_PLASMA            =  17, /**< Error is from plasma.c                   */
     EF_E_FIELD           =  18, /**< Error is from E_field.c                  */
@@ -50,7 +50,8 @@ typedef enum error_file {
     EF_ATOMIC            =  25, /**< Error is from atomic.c                   */
     EF_ASIGMA            =  26, /**< Error is from asigma.c                   */
     EF_ASIGMA_LOC        =  27, /**< Error is from asigma_loc.c               */
-    EF_SUZUKI            =  28  /**< Error is from suzuki.c                   */
+    EF_SUZUKI            =  28, /**< Error is from suzuki.c                   */
+    EF_PLASMA_2D         =  29  /**< Error is from plasma_2D.c                */
 }error_file;
 
 /**

--- a/src/error.h
+++ b/src/error.h
@@ -51,7 +51,8 @@ typedef enum error_file {
     EF_ASIGMA            =  26, /**< Error is from asigma.c                   */
     EF_ASIGMA_LOC        =  27, /**< Error is from asigma_loc.c               */
     EF_SUZUKI            =  28, /**< Error is from suzuki.c                   */
-    EF_PLASMA_2D         =  29  /**< Error is from plasma_2D.c                */
+    EF_PLASMA_2D         =  29, /**< Error is from plasma_2D.c                */
+    EF_E_2DS             =  30  /**< Error is from suzuki.c                   */
 }error_file;
 
 /**

--- a/src/gctransform.h
+++ b/src/gctransform.h
@@ -22,7 +22,7 @@ void gctransform_guidingcenter2particle(
     real R, real Phi, real Z, real ppar, real mu, real zeta,
     real* r, real* phi, real* z, real* pparprt, real* muprt, real* zetaprt);
 
-DECLARE_TARGET_SIMD
+GPU_DECLARE_TARGET_SIMD
 void gctransform_pparmuzeta2prpphipz(real mass, real charge, real* B_dB,
                                      real phi, real ppar, real mu, real zeta,
                                      real* pr, real* pphi, real* pz);

--- a/src/hdf5io/hdf5_efield.c
+++ b/src/hdf5io/hdf5_efield.c
@@ -22,12 +22,14 @@
 #include "../E_field.h"
 #include "../Efield/E_TC.h"
 #include "../Efield/E_1DS.h"
+#include "../Efield/E_2DS.h"
 #include "../print.h"
 #include "hdf5_helpers.h"
 #include "hdf5_efield.h"
 
 #define EPATH /**< Macro that is used to store paths to data groups */
 
+int hdf5_efield_read_2DS(hid_t f, E_2DS_data* data, char* qid);
 int hdf5_efield_read_1DS(hid_t f, E_1DS_data* data, char* qid);
 int hdf5_efield_read_TC(hid_t f, E_TC_data* data, char* qid);
 
@@ -65,6 +67,47 @@ int hdf5_efield_init(hid_t f, E_field_data* data, char* qid) {
         data->type = E_field_type_1DS;
         err = hdf5_efield_read_1DS(f, &data->E1DS, qid);
     }
+    hdf5_gen_path("/efield/E_2DS_XXXXXXXXXX", qid, path);
+    if(hdf5_find_group(f, path) == 0) {
+        data->type = E_field_type_2DS;
+        err = hdf5_efield_read_2DS(f, &data->E2DS, qid);
+    }
+    return err;
+}
+
+/**
+ * @brief Read E2DS electric field data from HDF5 file.
+ *
+ * @param f HDF5 file from which data is read
+ * @param data pointer to the data
+ * @param qid QID of the data
+ *
+ * @return Zero if reading succeeded
+ */
+int hdf5_efield_read_2DS(hid_t f, E_2DS_data* data, char* qid) {
+    #undef EPATH
+    #define EPATH "/efield/E_2DS_XXXXXXXXXX/"
+
+    int nr, nz;
+    real rmin, rmax, zmin, zmax;
+    if( hdf5_read_int(EPATH "nr", &nr,
+                      f, qid, __FILE__, __LINE__) ) {return 1;}
+    if( hdf5_read_double(EPATH "rmin", &rmin,
+                         f, qid, __FILE__, __LINE__) ) {return 1;}
+    if( hdf5_read_double(EPATH "rmax", &rmax,
+                         f, qid, __FILE__, __LINE__) ) {return 1;}
+    if( hdf5_read_int(EPATH "nz", &nz,
+                      f, qid, __FILE__, __LINE__) ) {return 1;}
+    if( hdf5_read_double(EPATH "zmin", &zmin,
+                         f, qid, __FILE__, __LINE__) ) {return 1;}
+    if( hdf5_read_double(EPATH "zmax", &zmax,
+                         f, qid, __FILE__, __LINE__) ) {return 1;}
+
+    real* vpot = (real*) malloc( nr*nz*sizeof(real) );
+    if( hdf5_read_double(EPATH "vpot", vpot,
+                         f, qid, __FILE__, __LINE__) ) {return 1;}
+    int err = E_2DS_init(data, nr, rmin, rmax, nz, zmin, zmax, vpot);
+    free(vpot);
     return err;
 }
 

--- a/src/linint/linint2D.c
+++ b/src/linint/linint2D.c
@@ -33,6 +33,8 @@ void linint2D_init(linint2D_data* str, real* c,
 
     str->n_x    = n_x;
     str->n_y    = n_y;
+    str->bc_x   = bc_x;
+    str->bc_y   = bc_y;
     str->x_min  = x_min;
     str->x_max  = x_max;
     str->x_grid = x_grid;

--- a/src/math.h
+++ b/src/math.h
@@ -149,7 +149,7 @@ void math_barycentric_coords_triangle(
 void math_uniquecount(int* in, int* unique, int* count, int n);
 DECLARE_TARGET_SIMD
 real* math_rsearch(const real key, const real* base, int num);
-DECLARE_TARGET_SIMD_UNIFORM(rv,zv,n)
+GPU_DECLARE_TARGET_SIMD_UNIFORM(rv,zv,n)
 int math_point_in_polygon(real r, real z, real* rv, real* zv, int n);
 
 

--- a/src/mhd.h
+++ b/src/mhd.h
@@ -40,7 +40,7 @@ typedef struct {
 
 void mhd_free(mhd_data* data);
 void mhd_offload(mhd_data* data);
-DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, Bdata, includemode)
+GPU_DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, Bdata, includemode)
 a5err mhd_eval(real mhd_dmhd[10], real r, real phi, real z, real t,
                int includemode, boozer_data* boozerdata, mhd_data* mhddata,
                B_field_data* Bdata);

--- a/src/mhd/mhd_nonstat.h
+++ b/src/mhd/mhd_nonstat.h
@@ -41,7 +41,7 @@ int mhd_nonstat_init(mhd_nonstat_data* data, int nmode, int nrho, int ntime,
                      real* omega_nm, real* phase_nm, real* alpha, real* phi);
 void mhd_nonstat_free(mhd_nonstat_data* data);
 void mhd_nonstat_offload(mhd_nonstat_data* data);
-DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, Bdata, includemode)
+GPU_DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, Bdata, includemode)
 a5err mhd_nonstat_eval(real mhd_dmhd[10], real r, real phi, real z, real t,
                        int includemode, boozer_data* boozerdata,
                        mhd_nonstat_data* mhddata, B_field_data* Bdata);

--- a/src/mhd/mhd_stat.h
+++ b/src/mhd/mhd_stat.h
@@ -42,7 +42,7 @@ int mhd_stat_init(mhd_stat_data* data, int nmode, int nrho,
                   real* alpha, real* phi);
 void mhd_stat_free(mhd_stat_data* data);
 void mhd_stat_offload(mhd_stat_data* data);
-DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, includemode)
+GPU_DECLARE_TARGET_SIMD_UNIFORM(boozerdata, mhddata, includemode)
 a5err mhd_stat_eval(
     real mhd_dmhd[10], real r, real phi, real z, real t, int includemode,
     boozer_data* boozerdata, mhd_stat_data* mhddata, B_field_data* Bdata);

--- a/src/offload.h
+++ b/src/offload.h
@@ -194,6 +194,23 @@
 #endif
 
 /**
+ * @brief Forces a function to be inlined into its callers
+ *
+ * For a helper that is called from inside a routine carrying an "omp declare
+ * simd" contract, being inlined is part of the contract rather than an
+ * optimization preference: if the compiler leaves the helper out of line, the
+ * SIMD clone of the caller degenerates into a per-lane scalar call and the
+ * vectorization the contract exists to obtain is lost. gcc applies its -O2
+ * size limits to "static inline" and will do exactly that for a helper of any
+ * size, so say what is meant instead of hinting at it.
+ */
+#if defined(__GNUC__)
+#define FORCE_INLINE __attribute__((always_inline))
+#else
+#define FORCE_INLINE
+#endif
+
+/**
  * @brief Makes a parallel region (CPU only)
  */
 #if defined(GPU)

--- a/src/offload.h
+++ b/src/offload.h
@@ -123,7 +123,11 @@
 #define DECLARE_TARGET_SIMD
 #elif defined(GPU) && defined(_OPENACC)
 #define DECLARE_TARGET_SIMD
+#elif defined(__INTEL_LLVM_COMPILER)
+/* icx: avoid vector-function ABI (fixes _ZGV... undefined references) */
+#define DECLARE_TARGET_SIMD
 #else
+#warning "omp declare simd"
 #define DECLARE_TARGET_SIMD str_pragma(omp declare simd)
 #endif
 
@@ -146,6 +150,9 @@
 #define GPU_DECLARE_TARGET_SIMD str_pragma(omp declare target)
 #elif defined(GPU) && defined(_OPENACC)
 #define GPU_DECLARE_TARGET_SIMD str_pragma(acc routine seq)
+#elif defined(__INTEL_LLVM_COMPILER)
+/* icx: avoid vector-function ABI (fixes _ZGV... undefined references) */
+#define GPU_DECLARE_TARGET_SIMD
 #else
 #define GPU_DECLARE_TARGET_SIMD str_pragma(omp declare simd)
 #endif
@@ -168,6 +175,8 @@
 #define GPU_DECLARE_TARGET_SIMD_UNIFORM(...) str_pragma(omp declare target)
 #elif defined(GPU) && defined(_OPENACC)
 #define GPU_DECLARE_TARGET_SIMD_UNIFORM(...) str_pragma(acc routine seq)
+#elif defined(__INTEL_LLVM_COMPILER)
+#define GPU_DECLARE_TARGET_SIMD_UNIFORM(...)
 #else
 #define GPU_DECLARE_TARGET_SIMD_UNIFORM(...) \
     str_pragma(omp declare simd uniform (__VA_ARGS__))

--- a/src/particle.h
+++ b/src/particle.h
@@ -274,53 +274,54 @@ typedef struct {
  */
 typedef struct {
     /* Physical coordinates and parameters */
-    real r[NSIMD] __memalign__;      /**< Guiding center R coordinate [m]     */
-    real phi[NSIMD] __memalign__;    /**< Guiding center phi coordinate [phi] */
-    real z[NSIMD] __memalign__;      /**< Guiding center z coordinate [m]     */
-    real ppar[NSIMD] __memalign__;   /**< Parallel momentum [kg m/s]          */
-    real mu[NSIMD] __memalign__;     /**< Magnetic moment [J/T]               */
-    real zeta[NSIMD] __memalign__;   /**< Gyroangle [rad]                     */
-    real mass[NSIMD] __memalign__;   /**< Mass [kg]                           */
-    real charge[NSIMD] __memalign__; /**< Charge [C]                          */
-    real time[NSIMD] __memalign__;   /**< Marker simulation time [s]          */
+    real* r;      /**< Guiding center R coordinate [m]     */
+    real* phi;    /**< Guiding center phi coordinate [phi] */
+    real* z;      /**< Guiding center z coordinate [m]     */
+    real* ppar;   /**< Parallel momentum [kg m/s]          */
+    real* mu;     /**< Magnetic moment [J/T]               */
+    real* zeta;   /**< Gyroangle [rad]                     */
+    real* mass;   /**< Mass [kg]                           */
+    real* charge; /**< Charge [C]                          */
+    real* time;   /**< Marker simulation time [s]          */
 
     /* Magnetic field data */
-    real B_r[NSIMD] __memalign__;        /**< Magnetic field R component at
+    real* B_r;        /**< Magnetic field R component at
                                               marker position [T]             */
-    real B_phi[NSIMD] __memalign__;      /**< Magnetic field phi component at
+    real* B_phi;      /**< Magnetic field phi component at
                                               marker position [T]             */
-    real B_z[NSIMD] __memalign__;        /**< Magnetic field z component at
+    real* B_z;        /**< Magnetic field z component at
                                               marker position [T]             */
 
-    real B_r_dr[NSIMD] __memalign__;     /**< dB_R/dR at marker pos. [T/m]    */
-    real B_phi_dr[NSIMD] __memalign__;   /**< dB_phi/dR at marker pos. [T/m]  */
-    real B_z_dr[NSIMD] __memalign__;     /**< dB_z/dR at marker pos. [T/m]    */
-    real B_r_dphi[NSIMD] __memalign__;   /**< dB_R/dphi at marker pos. [T/m]  */
-    real B_phi_dphi[NSIMD] __memalign__; /**< dB_phi/dphi at marker pos. [T/m]*/
-    real B_z_dphi[NSIMD] __memalign__;   /**< dB_z/dphi at marker pos. [T/m]  */
-    real B_r_dz[NSIMD] __memalign__;     /**< dB_R/dz at marker pos. [T/m]    */
-    real B_phi_dz[NSIMD] __memalign__;   /**< dB_phi/dz at marker pos. [T/m]  */
-    real B_z_dz[NSIMD] __memalign__;     /**< dB_z/dz at marker pos. [T/m]    */
+    real* B_r_dr;     /**< dB_R/dR at marker pos. [T/m]    */
+    real* B_phi_dr;   /**< dB_phi/dR at marker pos. [T/m]  */
+    real* B_z_dr;     /**< dB_z/dR at marker pos. [T/m]    */
+    real* B_r_dphi;   /**< dB_R/dphi at marker pos. [T/m]  */
+    real* B_phi_dphi; /**< dB_phi/dphi at marker pos. [T/m]*/
+    real* B_z_dphi;   /**< dB_z/dphi at marker pos. [T/m]  */
+    real* B_r_dz;     /**< dB_R/dz at marker pos. [T/m]    */
+    real* B_phi_dz;   /**< dB_phi/dz at marker pos. [T/m]  */
+    real* B_z_dz;     /**< dB_z/dz at marker pos. [T/m]    */
 
     /* Quantities used in diagnostics */
-    int bounces[NSIMD] __memalign__;  /**< Number of times pitch sign changed */
-    real weight[NSIMD] __memalign__;  /**< Marker weight                      */
-    real cputime[NSIMD] __memalign__; /**< Marker wall-clock time [s]         */
-    real rho[NSIMD] __memalign__;     /**< Marker rho coordinate              */
-    real theta[NSIMD] __memalign__;   /**< Marker poloidal coordinate [rad]   */
+    int* bounces;  /**< Number of times pitch sign changed */
+    real* weight;  /**< Marker weight                      */
+    real* cputime; /**< Marker wall-clock time [s]         */
+    real* rho;     /**< Marker rho coordinate              */
+    real* theta;   /**< Marker poloidal coordinate [rad]   */
 
-    integer id[NSIMD] __memalign__;       /**< Unique ID for the marker       */
-    integer endcond[NSIMD] __memalign__;  /**< Marker end condition           */
-    integer walltile[NSIMD] __memalign__; /**< ID of walltile if marker has
+    integer* id;       /**< Unique ID for the marker       */
+    integer* endcond;  /**< Marker end condition           */
+    integer* walltile; /**< ID of walltile if marker has
                                                hit the wall                   */
 
     /* Meta data */
-    real mileage[NSIMD] __memalign__;    /**< Duration this marker has been
+    real* mileage;    /**< Duration this marker has been
                                               simulated [s]                   */
-    integer running[NSIMD] __memalign__; /**< Indicates whether this marker is
+    integer* running; /**< Indicates whether this marker is
                                               currently simulated (1) or not  */
-    a5err err[NSIMD] __memalign__;       /**< Error flag, zero if no error    */
-    integer index[NSIMD] __memalign__;   /**< Marker index at marker queue    */
+    a5err* err;       /**< Error flag, zero if no error    */
+    integer* index;   /**< Marker index at marker queue    */
+    size_t n_mrk;     /**< How many markers this struct contains */
 } particle_simd_gc;
 
 /**
@@ -388,6 +389,7 @@ typedef struct {
 
 
 void particle_allocate_fo(particle_simd_fo* p_fo, int nmrk);
+void particle_allocate_gc(particle_simd_gc* p_gc, int nmrk);
 void particle_to_fo_dummy(particle_simd_fo* p_fo, int j);
 void particle_to_gc_dummy(particle_simd_gc* p_gc, int j);
 void particle_to_fo_dummy(particle_simd_fo* p_fo, int j);
@@ -412,6 +414,8 @@ a5err particle_input_ml_to_state(particle_ml* p, particle_state* ps,
 
 void particle_offload_fo(particle_simd_fo* p);
 void particle_onload_fo(particle_simd_fo* p);
+void particle_offload_gc(particle_simd_gc* p);
+void particle_onload_gc(particle_simd_gc* p);
 
 DECLARE_TARGET_SIMD_UNIFORM(Bdata)
 a5err particle_state_to_fo(particle_state* p, int i, particle_simd_fo* p_fo,
@@ -437,7 +441,7 @@ int particle_fo_to_gc(particle_simd_fo* p_fo, int j, particle_simd_gc* p_gc,
 GPU_DECLARE_TARGET_SIMD
 void particle_copy_fo(particle_simd_fo* p1, int i, particle_simd_fo* p2, int j);
 DECLARE_TARGET_END
-DECLARE_TARGET_SIMD
+GPU_DECLARE_TARGET_SIMD
 void particle_copy_gc(particle_simd_gc* p1, int i, particle_simd_gc* p2, int j);
 DECLARE_TARGET_SIMD
 void particle_copy_ml(particle_simd_ml* p1, int i, particle_simd_ml* p2, int j);

--- a/src/plasma.c
+++ b/src/plasma.c
@@ -27,6 +27,8 @@
 #include "print.h"
 #include "plasma.h"
 #include "plasma/plasma_1D.h"
+#include "plasma/plasma_2D.h"
+#include "plasma/plasma_1Dt.h"
 #include "plasma/plasma_1DS.h"
 #include "consts.h"
 
@@ -39,6 +41,9 @@ void plasma_free(plasma_data* data) {
     switch(data->type) {
         case plasma_type_1D:
             plasma_1D_free(&data->plasma_1D);
+            break;
+        case plasma_type_2D:
+            plasma_2D_free(&data->plasma_2D);
             break;
         case plasma_type_1Dt:
             plasma_1Dt_free(&data->plasma_1Dt);
@@ -58,6 +63,9 @@ void plasma_offload(plasma_data* data) {
     switch(data->type) {
         case plasma_type_1D:
             plasma_1D_offload(&data->plasma_1D);
+            break;
+        case plasma_type_2D:
+            plasma_2D_offload(&data->plasma_2D);
             break;
         case plasma_type_1Dt:
             plasma_1Dt_offload(&data->plasma_1Dt);
@@ -95,6 +103,11 @@ a5err plasma_eval_temp(real* temp, real rho, real r, real phi, real z, real t,
         case plasma_type_1D:
             err = plasma_1D_eval_temp(temp, rho, species,
                                       &(pls_data->plasma_1D));
+            break;
+
+        case plasma_type_2D:
+            err = plasma_2D_eval_temp(temp, r, z, species,
+                                      &(pls_data->plasma_2D));
             break;
 
         case plasma_type_1Dt:
@@ -143,6 +156,11 @@ a5err plasma_eval_dens(real* dens, real rho, real r, real phi, real z, real t,
         case plasma_type_1D:
             err = plasma_1D_eval_dens(dens, rho, species,
                                       &(pls_data->plasma_1D));
+            break;
+
+        case plasma_type_2D:
+            err = plasma_2D_eval_dens(dens, r, z, species,
+                                      &(pls_data->plasma_2D));
             break;
 
         case plasma_type_1Dt:
@@ -194,6 +212,11 @@ a5err plasma_eval_densandtemp(real* dens, real* temp, real rho,
                                              rho, &(pls_data->plasma_1D));
             break;
 
+        case plasma_type_2D:
+            err = plasma_2D_eval_densandtemp(dens, temp,
+                                             r, z, &(pls_data->plasma_2D));
+            break;
+
         case plasma_type_1Dt:
             err = plasma_1Dt_eval_densandtemp(dens, temp,
                                               rho, t, &(pls_data->plasma_1Dt));
@@ -209,7 +232,6 @@ a5err plasma_eval_densandtemp(real* dens, real* temp, real rho,
             err = error_raise( ERR_UNKNOWN_INPUT, __LINE__, EF_PLASMA );
             break;
     }
-
     if(err) {
         /* In case of error, return some reasonable values to avoid further
            complications */
@@ -242,6 +264,11 @@ a5err plasma_eval_flow(
         case plasma_type_1D:
             err = plasma_1D_eval_flow(
                 vflow, rho, r, &(pls_data->plasma_1D));
+            break;
+
+        case plasma_type_2D:
+            err = plasma_2D_eval_flow(
+                vflow, r, z, &(pls_data->plasma_2D));
             break;
 
         case plasma_type_1DS:
@@ -288,6 +315,10 @@ int plasma_get_n_species(plasma_data* pls_data) {
             n = pls_data->plasma_1D.n_species;
             break;
 
+        case plasma_type_2D:
+            n = pls_data->plasma_2D.n_species;
+            break;
+
         case plasma_type_1Dt:
             n = pls_data->plasma_1Dt.n_species;
             break;
@@ -316,6 +347,10 @@ const real* plasma_get_species_mass(plasma_data* pls_data) {
     switch(pls_data->type) {
         case plasma_type_1D:
             mass = pls_data->plasma_1D.mass;
+            break;
+
+        case plasma_type_2D:
+            mass = pls_data->plasma_2D.mass;
             break;
 
         case plasma_type_1Dt:
@@ -348,6 +383,10 @@ const real* plasma_get_species_charge(plasma_data* pls_data) {
             charge = pls_data->plasma_1D.charge;
             break;
 
+        case plasma_type_2D:
+            charge = pls_data->plasma_2D.charge;
+            break;
+
         case plasma_type_1Dt:
             charge = pls_data->plasma_1Dt.charge;
             break;
@@ -376,6 +415,10 @@ const int* plasma_get_species_znum(plasma_data* pls_data) {
             znum = pls_data->plasma_1D.znum;
             break;
 
+        case plasma_type_2D:
+            znum = pls_data->plasma_2D.znum;
+            break;
+
         case plasma_type_1Dt:
             znum = pls_data->plasma_1Dt.znum;
             break;
@@ -402,6 +445,10 @@ const int* plasma_get_species_anum(plasma_data* pls_data) {
     switch(pls_data->type) {
         case plasma_type_1D:
             anum = pls_data->plasma_1D.anum;
+            break;
+
+        case plasma_type_2D:
+            anum = pls_data->plasma_2D.anum;
             break;
 
         case plasma_type_1Dt:

--- a/src/plasma.h
+++ b/src/plasma.h
@@ -11,6 +11,7 @@
 #include "ascot5.h"
 #include "error.h"
 #include "plasma/plasma_1D.h"
+#include "plasma/plasma_2D.h"
 #include "plasma/plasma_1Dt.h"
 #include "plasma/plasma_1DS.h"
 
@@ -19,6 +20,7 @@
  */
 typedef enum plasma_type {
     plasma_type_1D,  /**< Linear-interpolated 1D plasma data                */
+    plasma_type_2D,  /**< Linear-interpolated 2D plasma data                */
     plasma_type_1Dt, /**< Linear-interpolated time-dependent 1D plasma data */
     plasma_type_1DS  /**< Spline-interpolated 1D plasma data                */
 } plasma_type;
@@ -32,6 +34,7 @@ typedef enum plasma_type {
 typedef struct {
     plasma_type type;           /**< Plasma data type wrapped by this struct */
     plasma_1D_data plasma_1D;   /**< 1D data or NULL if not active           */
+    plasma_2D_data plasma_2D;   /**< 2D data or NULL if not active           */
     plasma_1Dt_data plasma_1Dt; /**< 1D data or NULL if not active           */
     plasma_1DS_data plasma_1DS; /**< 1DS data or NULL if not active          */
 } plasma_data;

--- a/src/plasma/plasma_2D.c
+++ b/src/plasma/plasma_2D.c
@@ -1,0 +1,218 @@
+/**
+ * @file plasma_2D.c
+ * @brief 2D linearly interpolated plasma
+ *
+ * Plasma data which is defined in a (R,z) uniform grid from which the values
+ * are interpolated linearly.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../ascot5.h"
+#include "../error.h"
+#include "../consts.h"
+#include "../print.h"
+#include "../linint/linint.h"
+#include "plasma_2D.h"
+
+/**
+ * @brief Initialize 2D plasma data and check inputs
+ *
+ * @param data pointer to the data struct
+ *
+ * @return zero if initialization succes
+ */
+int plasma_2D_init(plasma_2D_data* data, int nr, int nz, int nion,
+                   real r_min, real r_max, real z_min, real z_max,
+                   int* anum, int* znum, real* mass, real* charge,
+                   real* Te, real* Ti, real* ne, real* ni, real* vtor) {
+
+    data->n_species = nion + 1;
+    data->anum = (int*) malloc( nion*sizeof(int) );
+    data->znum = (int*) malloc( nion*sizeof(int) );
+    data->mass = (real*) malloc( (nion+1)*sizeof(real) );
+    data->charge = (real*) malloc( (nion+1)*sizeof(real) );
+    for(int i = 0; i < data->n_species; i++) {
+        if(i < nion) {
+            data->znum[i] = znum[i];
+            data->anum[i] = anum[i];
+        }
+        data->mass[i] = mass[i];
+        data->charge[i] = charge[i];
+    }
+
+    data->dens = (linint2D_data*) malloc( (nion + 1) * sizeof(linint2D_data) );
+    data->temp = (linint2D_data*) malloc( 2 * sizeof(linint2D_data) );
+    data->vtor = (linint2D_data*) malloc( sizeof(linint2D_data) );
+    real* c = (real*) malloc(nr * nz * sizeof(real));
+    for(int j = 0; j < nr * nz; j++) {
+        c[j] = ne[j];
+    }
+    linint2D_init(
+        &data->dens[0], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,
+        z_min, z_max);
+
+    c = (real*) malloc(nr * nz * sizeof(real));
+    for(int j = 0; j < nr * nz; j++) {
+        c[j] = Te[j];
+    }
+    linint2D_init(
+        &data->temp[0], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,
+        z_min, z_max);
+
+    c = (real*) malloc(nr * nz * sizeof(real));
+    for(int j = 0; j < nr * nz; j++) {
+        c[j] = Ti[j];
+    }
+    linint2D_init(
+        &data->temp[1], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,
+        z_min, z_max);
+
+    c = (real*) malloc(nr * nz * sizeof(real));
+    for(int j = 0; j < nr * nz; j++) {
+        c[j] = vtor[j];
+    }
+    linint2D_init(
+        &data->vtor[0], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,
+        z_min, z_max);
+
+    for(int i = 0; i < nion; i++) {
+
+        c = (real*) malloc(nr * nz * sizeof(real));
+        for(int j = 0; j < nr * nz; j++) {
+            c[j] = ni[j + i * nion];
+        }
+        linint2D_init(
+            &data->dens[i+1], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,
+            z_min, z_max);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Free allocated resources
+ *
+ * @param data pointer to the data struct
+ */
+void plasma_2D_free(plasma_2D_data* data) {
+    free(data->anum);
+    free(data->znum);
+    free(data->mass);
+    free(data->charge);
+    for(int i = 0; i < data->n_species; i++) {
+        free(data->dens[i].c);
+    }
+    free(data->temp[0].c);
+    free(data->temp[1].c);
+    free(data->vtor[0].c);
+    free(data->dens);
+    free(data->temp);
+    free(data->vtor);
+}
+
+/**
+ * @brief Offload data to the accelerator.
+ *
+ * @param data pointer to the data struct
+ */
+void plasma_2D_offload(plasma_2D_data* data) {
+    //TODO: Implement
+}
+
+/**
+ * @brief Evaluate plasma temperature
+ *
+ * This function evaluates the temperature of a plasma species at the given
+ * radial coordinate using linear interpolation.
+ *
+ * @param temp pointer to where evaluated temperature [J] is stored
+ * @param r R coordinate
+ * @param z z coordinate
+ * @param species index of plasma species
+ * @param pls_data pointer to plasma data struct
+ *
+ * @return zero if evaluation succeeded
+ */
+a5err plasma_2D_eval_temp(real* temp, real r, real z, int species,
+                          plasma_2D_data* pls_data) {
+    a5err err = 0;
+    int i = species > 0;
+    int interperr = linint2D_eval_f(temp, &pls_data->temp[i], r, z);
+    if(interperr) {
+        err = error_raise(ERR_INPUT_EVALUATION, __LINE__, EF_PLASMA_2D);
+    }
+    return err;
+}
+
+/**
+ * @brief Evaluate plasma density
+ *
+ * This function evaluates the density of a plasma species at the given
+ * radial coordinate using linear interpolation.
+ *
+ * @param dens pointer to where evaluated density [m^-3] is stored
+ * @param r R coordinate
+ * @param z z coordinate
+ * @param species index of plasma species
+ * @param pls_data pointer to plasma data struct
+ *
+ * @return zero if evaluation succeeded
+ */
+a5err plasma_2D_eval_dens(real* dens, real r, real z, int species,
+                          plasma_2D_data* pls_data) {
+    a5err err = 0;
+    int interperr = linint2D_eval_f(dens, &pls_data->dens[species], r, z);
+    if(interperr) {
+        err = error_raise(ERR_INPUT_EVALUATION, __LINE__, EF_PLASMA_2D);
+    }
+    return err;
+}
+
+/**
+ * @brief Evaluate plasma density and temperature for all species
+ *
+ * This function evaluates the density and temperature of all plasma species at
+ * the given radial coordinate using linear interpolation.
+ *
+ * @param dens pointer to where interpolated densities [m^-3] are stored
+ * @param temp pointer to where interpolated temperatures [J] are stored
+ * @param r R coordinate
+ * @param z z coordinate
+ * @param pls_data pointer to plasma data struct
+ *
+ * @return zero if evaluation succeeded
+ */
+a5err plasma_2D_eval_densandtemp(real* dens, real* temp, real r, real z,
+                                 plasma_2D_data* pls_data) {
+    int interperr = 0;
+    for(int i = 0; i < pls_data->n_species; i++) {
+        int ision = i > 0;
+        interperr += linint2D_eval_f(&temp[i], &pls_data->temp[ision], r, z);
+        interperr += linint2D_eval_f(&dens[i], &pls_data->dens[i], r, z);
+    }
+    a5err err = 0;
+    if(interperr) {
+        err = error_raise(ERR_INPUT_EVALUATION, __LINE__, EF_PLASMA_2D);
+    }
+    return err;
+}
+
+/**
+ * @brief Evalate plasma flow along the field lines
+ *
+ * @param vflow pointer where the flow value is stored [m/s]
+ * @param r R coordinate
+ * @param z z coordinate
+ * @param pls_data pointer to plasma data
+ */
+a5err plasma_2D_eval_flow(real* vflow, real r, real z,
+                          plasma_2D_data* pls_data) {
+    a5err err = 0;
+    int interperr = linint2D_eval_f(vflow, pls_data->vtor, r, z);
+    if(interperr) {
+        err = error_raise(ERR_INPUT_EVALUATION, __LINE__, EF_PLASMA_2D);
+    }
+    *vflow *= r;
+    return err;
+}

--- a/src/plasma/plasma_2D.c
+++ b/src/plasma/plasma_2D.c
@@ -80,7 +80,7 @@ int plasma_2D_init(plasma_2D_data* data, int nr, int nz, int nion,
 
         c = (real*) malloc(nr * nz * sizeof(real));
         for(int j = 0; j < nr * nz; j++) {
-            c[j] = ni[j + i * nion];
+            c[j] = ni[i * (nr * nz) + j];
         }
         linint2D_init(
             &data->dens[i+1], c, nr, nz, NATURALBC, NATURALBC, r_min, r_max,

--- a/src/plasma/plasma_2D.h
+++ b/src/plasma/plasma_2D.h
@@ -1,0 +1,49 @@
+/**
+ * @file plasma_2D.h
+ * @brief Header file for plasma_2D.c
+ */
+#ifndef PLASMA_2D_H
+#define PLASMA_2D_H
+#include "../ascot5.h"
+#include "../offload.h"
+#include "../error.h"
+#include "../linint/linint.h"
+
+/**
+ * @brief 1D plasma parameters on the target
+ */
+typedef struct {
+    int n_species;       /**< number of plasma species including electrons */
+    real* mass;          /**< plasma species masses [kg]                   */
+    real* charge;        /**< plasma species charges [C]                   */
+    int* anum;           /**< ion species atomic number                    */
+    int* znum;           /**< ion species charge number                    */
+    linint2D_data* temp; /**< temperature interpolant                      */
+    linint2D_data* dens; /**< density interpolant                          */
+    linint2D_data* vtor; /**< toroidal rotation interpolant                */
+} plasma_2D_data;
+
+int plasma_2D_init(plasma_2D_data* data, int nr, int nz, int nion,
+                   real r_min, real r_max, real z_min, real z_max,
+                   int* anum, int* znum, real* mass, real* charge,
+                   real* Te, real* Ti, real* ne, real* ni, real* vtor);
+void plasma_2D_free(plasma_2D_data* data);
+void plasma_2D_offload(plasma_2D_data* data);
+GPU_DECLARE_TARGET_SIMD_UNIFORM(pls_data)
+a5err plasma_2D_eval_temp(real* dens, real r, real z, int species,
+                          plasma_2D_data* pls_data);
+DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(pls_data)
+a5err plasma_2D_eval_dens(real* temp, real r, real z, int species,
+                          plasma_2D_data* pls_data);
+DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(pls_data)
+a5err plasma_2D_eval_densandtemp(real* dens, real* temp, real r, real z,
+                                 plasma_2D_data* pls_data);
+DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(pls_data)
+a5err plasma_2D_eval_flow(real* vflow, real r, real z,
+                          plasma_2D_data* pls_data);
+DECLARE_TARGET_END
+
+#endif

--- a/src/random.c
+++ b/src/random.c
@@ -115,10 +115,11 @@ void random_lcg_normal_simd(random_data* rdata, int n, double* r) {
     /* The geometric form */
     GPU_PARALLEL_LOOP_ALL_LEVELS
     for(int i = 0; i < n; i=i+2) {
+        random_data* ri = random_lcg_state_at(rdata, i);
         w = 2.0;
         while( w >= 1.0 ) {
-            x1 = 2*random_lcg_uniform(rdata)-1;
-            x2 = 2*random_lcg_uniform(rdata)-1;
+            x1 = 2*random_lcg_uniform(ri)-1;
+            x2 = 2*random_lcg_uniform(ri)-1;
             w = x1*x1 + x2*x2;
         }
 
@@ -133,8 +134,9 @@ void random_lcg_normal_simd(random_data* rdata, int n, double* r) {
     double s;
     GPU_PARALLEL_LOOP_ALL_LEVELS
     for(int i = 0; i < n; i=i+2) {
-        x1 = random_lcg_uniform(rdata);
-        x2 = random_lcg_uniform(rdata);
+        random_data* ri = random_lcg_state_at(rdata, i);
+        x1 = random_lcg_uniform(ri);
+        x2 = random_lcg_uniform(ri);
         w = sqrt(-2*log(x1));
         s = cos(CONST_2PI*x2);
         r[i] = w*s;

--- a/src/random.h
+++ b/src/random.h
@@ -61,6 +61,19 @@ typedef struct {
     uint64_t r;
 } random_data;
 
+/* Return the RNG state to use for logical index i.
+ * - CPU: a single RNG state is used
+ * - GPU: one RNG state per parallel slot/lane is used
+*/
+static inline random_data* random_lcg_state_at(random_data* rdata, int i) {
+#ifdef GPU
+    return &rdata[i];
+#else
+    (void)i;
+    return rdata;
+#endif
+}
+
 void random_lcg_init(random_data* rdata, uint64_t seed);
 uint64_t random_lcg_integer(random_data* rdata);
 DECLARE_TARGET

--- a/src/simulate.c
+++ b/src/simulate.c
@@ -99,8 +99,12 @@ void simulate(int n_particles, particle_state* p, sim_data* sim) {
     simulate_init(sim);
 
 #ifdef GPU
-    if(sim->sim_mode != 1) {
-        print_err("Only GO mode ported to GPU. Please set SIM_MODE=1.");
+    if((sim->sim_mode != 1) && (sim->sim_mode != 2)) {
+        print_err("Only GO and GC mode ported to GPU. Please set SIM_MODE=1 or 2.");
+        exit(1);
+    }
+    if(sim->enable_icrh) {
+        print_err("ENABLE_ICRH=1 not ported to GPU. Please disable it.");
         exit(1);
     }
     if(sim->record_mode) {
@@ -125,6 +129,7 @@ void simulate(int n_particles, particle_state* p, sim_data* sim) {
             "ENABLE_TRANSCOEF=1 not ported to GPU. Please disable it.");
         exit(1);
     }
+    
 #endif
 
     diag_init(&sim->diag_data, n_particles);
@@ -143,8 +148,26 @@ void simulate(int n_particles, particle_state* p, sim_data* sim) {
     /* 2. Meta data (e.g. random number generator) is initialized.            */
     /*                                                                        */
     /**************************************************************************/
-    random_init(&sim->random_data, 0);
-
+#ifdef GPU
+    /* On GPU we need one RNG state per parallel slot (thread/lane).
+     * data_size is a safety factor (number of RNGs used per particle/loop).
+     * Total number of RNG states = data_size * n_queue_size.
+     */
+    int data_size = 5;
+    /* Allocate an array of RNG states (one per parallel element) */
+    sim->random_data = malloc(data_size * n_queue_size * sizeof(random_data));
+    /* Initialize each RNG state with a different seed.
+     * Using i ensures independent sequences across threads.
+     */
+    for(int i = 0; i < data_size * n_queue_size; ++i) {
+        random_init(&sim->random_data[i], i);
+    }
+    /* Transfer RNG states to the GPU device memory */
+    GPU_MAP_TO_DEVICE(sim->random_data[0:data_size * n_queue_size])
+#else
+    sim->random_data = malloc(sizeof(random_data));
+    random_init(sim->random_data, 0);
+#endif
     /**************************************************************************/
     /* 3. Markers are put into simulation queue.                              */
     /*                                                                        */
@@ -192,12 +215,12 @@ void simulate(int n_particles, particle_state* p, sim_data* sim) {
             if(pq.n > 0 && (sim->sim_mode == simulate_mode_gc
                         || sim->sim_mode == simulate_mode_hybrid)) {
                 if(sim->enable_ada) {
-                    OMP_PARALLEL_CPU_ONLY
-                    simulate_gc_adaptive(&pq, sim);
+		    OMP_PARALLEL_CPU_ONLY
+		    simulate_gc_adaptive(&pq, sim, n_queue_size);
                 }
                 else {
                     OMP_PARALLEL_CPU_ONLY
-                    simulate_gc_fixed(&pq, sim);
+                    simulate_gc_fixed(&pq, sim, n_queue_size);
                 }
             }
             else if(pq.n > 0 && sim->sim_mode == simulate_mode_fo) {

--- a/src/simulate.h
+++ b/src/simulate.h
@@ -71,7 +71,7 @@ typedef struct {
                                     parameters Fortran structs.               */
 
     /* Metadata */
-    random_data random_data;   /**< Random number generator                   */
+    random_data* random_data;   /**< Random number generator                   */
     mccc_data mccc_data;       /**< Tabulated special functions and collision
                                     operator parameters                       */
     /* Options - general */

--- a/src/simulate/mccc/mccc_gc_euler.c
+++ b/src/simulate/mccc/mccc_gc_euler.c
@@ -65,7 +65,6 @@ void mccc_gc_euler(particle_simd_gc* p, real* h, B_field_data* Bdata,
             vperp2 = (1 - xiin * xiin) * vin * vin;
             vin = sqrt((vpar - vflow) * (vpar - vflow) + vperp2);
             xiin =  (vpar - vflow) / vin;
-            
 
             /* Evaluate plasma density and temperature */
             real nb[MAX_SPECIES], Tb[MAX_SPECIES];

--- a/src/simulate/mccc/mccc_gc_euler.c
+++ b/src/simulate/mccc/mccc_gc_euler.c
@@ -49,7 +49,7 @@ void mccc_gc_euler(particle_simd_gc* p, real* h, B_field_data* Bdata,
             real z0   = p->z[i];
 
             /* Move guiding center to (x, y, z, vnorm, xi) coordinates */
-            real vin, pin, vflow, gamma, ppar_flow, xiin, Xin_xyz[3];
+            real vin, pin, vflow, vpar, vperp2, xiin, Xin_xyz[3];
             Xin_xyz[0] = p->r[i] * cos(p->phi[i]);
             Xin_xyz[1] = p->r[i] * sin(p->phi[i]);
             Xin_xyz[2] = p->z[i];
@@ -58,11 +58,14 @@ void mccc_gc_euler(particle_simd_gc* p, real* h, B_field_data* Bdata,
                     &vflow, p->rho[i], p->r[i], p->phi[i], p->z[i], p->time[i],
                     pdata);
             }
-            gamma = physlib_gamma_ppar(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
-            ppar_flow = p->ppar[i] - gamma * vflow * p->mass[i];
-            pin  = physlib_gc_p(p->mass[i], p->mu[i], ppar_flow, Bnorm);
-            xiin = physlib_gc_xi(p->mass[i], p->mu[i], ppar_flow, Bnorm);
+            pin  = physlib_gc_p(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
+            xiin = physlib_gc_xi(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
             vin = physlib_vnorm_pnorm(p->mass[i], pin);
+            vpar = xiin * vin;
+            vperp2 = (1 - xiin * xiin) * vin * vin;
+            vin = sqrt((vpar - vflow) * (vpar - vflow) + vperp2);
+            xiin =  (vpar - vflow) / vin;
+            
 
             /* Evaluate plasma density and temperature */
             real nb[MAX_SPECIES], Tb[MAX_SPECIES];
@@ -154,6 +157,10 @@ void mccc_gc_euler(particle_simd_gc* p, real* h, B_field_data* Bdata,
                 Xout_xyz[1] = Xin_xyz[1];
                 Xout_xyz[2] = Xin_xyz[2];
             }
+            vpar = xiout * vout;
+            vperp2 = (1 - xiout * xiout) * vout * vout;
+            vout = sqrt((vpar + vflow) * (vpar + vflow) + vperp2);
+            xiout =  (vpar + vflow) / vout;
             real pout = physlib_pnorm_vnorm(p->mass[i], vout);
 
             /* Back to cylindrical coordinates */
@@ -199,21 +206,8 @@ void mccc_gc_euler(particle_simd_gc* p, real* h, B_field_data* Bdata,
 
                 p->r[i]    = Xout_rpz[0];
                 p->z[i]    = Xout_rpz[2];
-
-                /*Since we use xiout (in "flow frame") here, we will get the mu
-                in the "flow frame". If we assume that the flow frame has the
-                same perpendicular velocity, mu remains unchanged under the
-                co-ordinate transformation and thus this mu is then the same as
-                the mu in the lab frame.*/
                 p->mu[i]   = physlib_gc_mu(p->mass[i], pout, xiout, Bnorm);
-                gamma      = physlib_gamma_pnorm(p->mass[i], pout);
-
-                /* difference in ppar between the lab frame and "flow frame"  */
-                real dppar  = gamma * p->mass[i] * vflow;
-
-                /* p->ppar is in the lab frame; xiout and pout are in the
-                "flow frame" */
-                p->ppar[i] = physlib_gc_ppar(pout, xiout) + dppar;
+                p->ppar[i] = physlib_gc_ppar(pout, xiout);
 
                 /* Evaluate phi and theta angles so that they are cumulative */
                 real axisrz[2];

--- a/src/simulate/mccc/mccc_gc_milstein.c
+++ b/src/simulate/mccc/mccc_gc_milstein.c
@@ -55,7 +55,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             real z0   = p->z[i];
 
             /* Move guiding center to (x, y, z, vnorm, xi) coordinates */
-            real vin, pin, vflow, gamma, ppar_flow, xiin, Xin_xyz[3];
+            real vin, pin, vflow, xiin, Xin_xyz[3], vpar, vperp2;
             Xin_xyz[0] = p->r[i] * cos(p->phi[i]);
             Xin_xyz[1] = p->r[i] * sin(p->phi[i]);
             Xin_xyz[2] = p->z[i];
@@ -64,11 +64,13 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
                     &vflow, p->rho[i], p->r[i], p->phi[i], p->z[i], p->time[i],
                     pdata);
             }
-            gamma = physlib_gamma_ppar(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
-            ppar_flow = p->ppar[i] - gamma * vflow * p->mass[i];
-            pin  = physlib_gc_p(p->mass[i], p->mu[i], ppar_flow, Bnorm);
-            xiin = physlib_gc_xi(p->mass[i], p->mu[i], ppar_flow, Bnorm);
+            pin  = physlib_gc_p(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
+            xiin = physlib_gc_xi(p->mass[i], p->mu[i], p->ppar[i], Bnorm);
             vin = physlib_vnorm_pnorm(p->mass[i], pin);
+            vpar = xiin * vin;
+            vperp2 = (1 - xiin * xiin) * vin * vin;
+            vin = sqrt((vpar - vflow) * (vpar - vflow) + vperp2);
+            xiin =  vpar / vin;
 
             /* Evaluate plasma density and temperature */
             real nb[MAX_SPECIES], Tb[MAX_SPECIES];
@@ -197,6 +199,11 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
                 Xout_xyz[1] = Xin_xyz[1];
                 Xout_xyz[2] = Xin_xyz[2];
             }
+
+            vpar = xiout * vout;
+            vperp2 = (1 - xiout * xiout) * vout * vout;
+            vout = sqrt((vpar + vflow) * (vpar + vflow) + vperp2);
+            xiout =  vpar / vout;       
             real pout = physlib_pnorm_vnorm(p->mass[i], vout);
 
             /* Back to cylindrical coordinates */
@@ -242,20 +249,8 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
 
                 p->r[i]    = Xout_rpz[0];
                 p->z[i]    = Xout_rpz[2];
-
-                /*Since we use xiout (in "flow frame") here, we will get the mu
-                in the "flow frame". If we assume that the flow frame has the
-                same perpendicular velocity, mu remains unchanged under the
-                co-ordinate transformation and thus this mu is then the same as
-                the mu in the lab frame.*/
                 p->mu[i]   = physlib_gc_mu(p->mass[i], pout, xiout, Bnorm);
-                gamma      = physlib_gamma_pnorm(p->mass[i], pout);
-                /* difference in ppar between the lab frame and "flow frame"  */
-                real dppar  = gamma * p->mass[i] * vflow;
-
-                /* p->ppar is in the lab frame; xiout and pout are in the
-                "flow frame" */
-                p->ppar[i] = physlib_gc_ppar(pout, xiout) + dppar;
+                p->ppar[i] = physlib_gc_ppar(pout, xiout);
 
                 /* Evaluate phi and theta angles so that they are cumulative */
                 real axisrz[2];

--- a/src/simulate/mccc/mccc_gc_milstein.c
+++ b/src/simulate/mccc/mccc_gc_milstein.c
@@ -203,7 +203,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             vpar = xiout * vout;
             vperp2 = (1 - xiout * xiout) * vout * vout;
             vout = sqrt((vpar + vflow) * (vpar + vflow) + vperp2);
-            xiout =  (vpar + vflow) / vout;       
+            xiout =  (vpar + vflow) / vout;
             real pout = physlib_pnorm_vnorm(p->mass[i], vout);
 
             /* Back to cylindrical coordinates */

--- a/src/simulate/mccc/mccc_gc_milstein.c
+++ b/src/simulate/mccc/mccc_gc_milstein.c
@@ -40,8 +40,9 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
     const real* qb = plasma_get_species_charge(pdata);
     const real* mb = plasma_get_species_mass(pdata);
 
-    #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_DATA_IS_MAPPED(hin[0:p->n_mrk], hout[0:p->n_mrk], rnd[0:5*p->n_mrk], w[0:p->n_mrk], acc[0:p->n_mrk], collfreq[0:p->n_mrk])
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p->n_mrk; i++) {
         if(p->running[i]) {
             a5err errflag = 0;
 
@@ -87,6 +88,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             real gyrofreq = phys_gyrofreq_pnorm(p->mass[i], p->charge[i], pin,
                                                 Bnorm);
             real K = 0, Dpara = 0, dDpara = 0, dQ = 0, nu = 0, DX = 0;
+	    GPU_SEQUENTIAL_LOOP
             for(int j = 0; j < n_species; j++) {
                 real vb = sqrt( 2 * Tb[j] / mb[j] );
                 real x  = vin / vb;
@@ -123,7 +125,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             }
             real dW[5] = {0, 0, 0, 0, 0};
             if(!errflag) {
-                dW[0] = w[i].wiener[tindex*5 + 0] - w[i].wiener[0]; // For X_1
+  	        dW[0] = w[i].wiener[tindex*5 + 0] - w[i].wiener[0]; // For X_1
                 dW[1] = w[i].wiener[tindex*5 + 1] - w[i].wiener[1]; // For X_2
                 dW[2] = w[i].wiener[tindex*5 + 2] - w[i].wiener[2]; // For X_3
                 dW[3] = w[i].wiener[tindex*5 + 3] - w[i].wiener[3]; // For v

--- a/src/simulate/mccc/mccc_gc_milstein.c
+++ b/src/simulate/mccc/mccc_gc_milstein.c
@@ -70,7 +70,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             vpar = xiin * vin;
             vperp2 = (1 - xiin * xiin) * vin * vin;
             vin = sqrt((vpar - vflow) * (vpar - vflow) + vperp2);
-            xiin =  vpar / vin;
+            xiin =  (vpar - vflow) / vin;
 
             /* Evaluate plasma density and temperature */
             real nb[MAX_SPECIES], Tb[MAX_SPECIES];
@@ -203,7 +203,7 @@ void mccc_gc_milstein(particle_simd_gc* p, real* hin, real* acc, real* collfreq,
             vpar = xiout * vout;
             vperp2 = (1 - xiout * xiout) * vout * vout;
             vout = sqrt((vpar + vflow) * (vpar + vflow) + vperp2);
-            xiout =  vpar / vout;       
+            xiout =  (vpar + vflow) / vout;       
             real pout = physlib_pnorm_vnorm(p->mass[i], vout);
 
             /* Back to cylindrical coordinates */

--- a/src/simulate/mccc/mccc_wiener.c
+++ b/src/simulate/mccc/mccc_wiener.c
@@ -49,6 +49,36 @@ void mccc_wiener_initialize(mccc_wienarr* w, real initime){
 }
 
 /**
+ * @brief Offload data to the accelerator.
+ *
+ * @param w pointer to the data struct
+ * @param size of the data struct
+ */
+void mccc_wiener_offload(mccc_wienarr* w, int mrk_array_size) {
+  GPU_MAP_TO_DEVICE(w[0:mrk_array_size])
+    for (int i = 0; i < mrk_array_size; i++) {
+      GPU_MAP_TO_DEVICE( w[i].nextslot[0:MCCC_NSLOTS] )
+      GPU_MAP_TO_DEVICE( w[i].time[0:MCCC_NSLOTS] )
+      GPU_MAP_TO_DEVICE( w[i].wiener[0:MCCC_NDIM*MCCC_NSLOTS] )
+     }
+    
+}
+
+/**
+ * @brief Onload data from the GPU.
+ *
+ * @param w pointer to the data struct
+ * @param size of the data struct
+ */
+void mccc_wiener_onload(mccc_wienarr* w, int mrk_array_size) {
+    for (int i = 0; i < mrk_array_size; i++) {
+      GPU_UPDATE_FROM_DEVICE( w[i].nextslot )
+      GPU_UPDATE_FROM_DEVICE( w[i].time )
+      GPU_UPDATE_FROM_DEVICE( w[i].wiener )
+     }
+}
+
+ /**
  * @brief Generates a new Wiener process at a given time instant
  *
  * Generates a new Wiener process. The generated process is drawn from

--- a/src/simulate/mccc/mccc_wiener.h
+++ b/src/simulate/mccc/mccc_wiener.h
@@ -39,8 +39,10 @@ typedef struct {
 DECLARE_TARGET_SIMD
 void mccc_wiener_initialize(mccc_wienarr* w, real initime);
 DECLARE_TARGET_SIMD
+GPU_DECLARE_TARGET_SIMD
 a5err mccc_wiener_generate(mccc_wienarr* w, real t, int* windex, real* rand5);
-DECLARE_TARGET_SIMD
+GPU_DECLARE_TARGET_SIMD
 a5err mccc_wiener_clean(mccc_wienarr* w, real t);
-
+void mccc_wiener_offload(mccc_wienarr* w, int mrk_array_size);
+void mccc_wiener_onload(mccc_wienarr* w, int mrk_array_size);
 #endif

--- a/src/simulate/simulate_fo_fixed.c
+++ b/src/simulate/simulate_fo_fixed.c
@@ -129,13 +129,13 @@ void simulate_fo_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size) {
 
         /* Euler-Maruyama for Coulomb collisions */
         if(sim->enable_clmbcol) {
-            random_normal_simd(&sim->random_data, 3*p.n_mrk, rnd);
+            random_normal_simd(sim->random_data, 3*p.n_mrk, rnd);
             mccc_fo_euler(&p, hin, &sim->plasma_data, &sim->mccc_data, rnd);
         }
         /* Atomic reactions */
         if(sim->enable_atomic) {
             atomic_fo(&p, hin, &sim->plasma_data, &sim->neutral_data,
-                      &sim->random_data, &sim->asigma_data);
+                      sim->random_data, &sim->asigma_data);
         }
         /**********************************************************************/
 

--- a/src/simulate/simulate_fo_fixed.c
+++ b/src/simulate/simulate_fo_fixed.c
@@ -59,6 +59,15 @@ void simulate_fo_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size) {
     particle_allocate_fo(&p, mrk_array_size);
     particle_allocate_fo(&p0, mrk_array_size);
 
+    particle_simd_gc gc_f;
+    particle_simd_gc gc_i;
+    if(sim->record_mode) {
+        particle_allocate_gc(&gc_f, mrk_array_size);
+        particle_allocate_gc(&gc_i, mrk_array_size);
+        particle_offload_gc(&gc_f);
+        particle_offload_gc(&gc_i);
+    }
+
     /* Init dummy markers */
     for(int i = 0; i < mrk_array_size; i++) {
         p.id[i] = -1;
@@ -69,7 +78,7 @@ void simulate_fo_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size) {
     int n_running = particle_cycle_fo(pq, &p, &sim->B_data, cycle);
 
     /* Determine simulation time-step */
-    #pragma omp simd
+    GPU_PARALLEL_LOOP_ALL_LEVELS
     for(int i = 0; i < mrk_array_size; i++) {
         if(cycle[i] > 0) {
             hin[i] = simulate_fo_fixed_inidt(sim, &p, i);
@@ -163,12 +172,8 @@ void simulate_fo_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size) {
         else {
             /* Instead of particle coordinates we record guiding center */
 
-            // Dummy guiding centers
-            particle_simd_gc gc_f;
-            particle_simd_gc gc_i;
-
             /* Particle to guiding center transformation */
-            #pragma omp simd
+            GPU_PARALLEL_LOOP_ALL_LEVELS
             for(int i=0; i<p.n_mrk; i++) {
                 if(p.running[i]) {
                     particle_fo_to_gc(&p, i, &gc_f, &sim->B_data);

--- a/src/simulate/simulate_gc_adaptive.c
+++ b/src/simulate/simulate_gc_adaptive.c
@@ -52,23 +52,23 @@ real simulate_gc_adaptive_inidt(sim_data* sim, particle_simd_gc* p, int i);
  * @param sim simulation data
  *
  */
-void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
+void simulate_gc_adaptive(particle_queue* pq, sim_data* sim, int mrk_array_size) {
 
     /* Wiener arrays needed for the adaptive time step */
-    mccc_wienarr wienarr[NSIMD];
+    mccc_wienarr* wienarr = (mccc_wienarr*) malloc(mrk_array_size*sizeof(mccc_wienarr));
 
     /* Current time step, suggestions for the next time step and next time
      * step                                                                */
-    real hin[NSIMD]       __memalign__;
-    real hout_orb[NSIMD]  __memalign__;
-    real hout_col[NSIMD]  __memalign__;
-    real hout_rfof[NSIMD] __memalign__;
-    real hnext[NSIMD]     __memalign__;
+    real* hin = (real*) malloc(mrk_array_size*sizeof(real));
+    real* hout_orb = (real*) malloc(mrk_array_size*sizeof(real));
+    real* hout_col = (real*) malloc(mrk_array_size*sizeof(real));
+    real* hout_rfof = (real*) malloc(mrk_array_size*sizeof(real));
+    real* hnext = (real*) malloc(mrk_array_size*sizeof(real));
 
     Acceleration acceleration;
-
+    acceleration_allocate(&acceleration, mrk_array_size);
     /* Flag indicateing whether a new marker was initialized */
-    int cycle[NSIMD]     __memalign__;
+    int* cycle = (int*) malloc(mrk_array_size*sizeof(int));
 
     real tol_col = sim->ada_tol_clmbcol;
     real tol_orb = sim->ada_tol_orbfol;
@@ -77,10 +77,12 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
 
     particle_simd_gc p;  // This array holds current states
     particle_simd_gc p0; // This array stores previous states
-
+    particle_allocate_gc(&p, mrk_array_size);
+    particle_allocate_gc(&p0, mrk_array_size);
+    
     rfof_marker rfof_mrk; // RFOF specific data
 
-    for(int i=0; i< NSIMD; i++) {
+    for(int i=0; i< mrk_array_size; i++) {
         p.id[i] = -1;
         p.running[i] = 0;
         acceleration.acc[i] = 1.0;
@@ -96,7 +98,7 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
     }
 
     #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    for(int i = 0; i < mrk_array_size; i++) {
         if(cycle[i] > 0) {
             /* Determine initial time-step */
             hin[i] = simulate_gc_adaptive_inidt(sim, &p, i);
@@ -121,11 +123,17 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
      * - Check for end condition(s)
      * - Update diagnostics
      */
+    real* rnd = (real*) malloc(5*mrk_array_size*sizeof(real));
+    particle_offload_gc(&p);
+    particle_offload_gc(&p0);
+    acceleration_offload(&acceleration,mrk_array_size);
+    GPU_MAP_TO_DEVICE(hin[0:mrk_array_size],rnd[0:5*mrk_array_size],hout_orb[0:mrk_array_size],hout_col[0:mrk_array_size],hout_rfof[0:mrk_array_size],hnext[0:mrk_array_size],cycle[0:mrk_array_size])
+    mccc_wiener_offload(wienarr,mrk_array_size);   
     while(n_running > 0) {
 
         /* Store marker states in case time step will be rejected */
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             particle_copy_gc(&p, i, &p0, i);
             hout_orb[i]  = DUMMY_TIMESTEP_VAL;
             hout_col[i]  = DUMMY_TIMESTEP_VAL;
@@ -136,8 +144,8 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
         /*************************** Physics **********************************/
 
         /* Set time-step negative if tracing backwards in time */
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             if(sim->reverse_time) {
                 hin[i]  = -hin[i];
             }
@@ -156,8 +164,8 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
                     sim->enable_aldforce);
             }
             /* Check whether time step was rejected */
-            #pragma omp simd
-            for(int i = 0; i < NSIMD; i++) {
+            GPU_PARALLEL_LOOP_ALL_LEVELS
+            for(int i = 0; i < p.n_mrk; i++) {
                 /* Switch sign of the time-step again if it was reverted earlier
                 */
                 if(sim->reverse_time) {
@@ -173,16 +181,14 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
 
         /* Milstein method for collisions */
         if(sim->enable_clmbcol) {
-            real rnd[5*NSIMD];
-            random_normal_simd(&sim->random_data, 5*NSIMD, rnd);
-            mccc_gc_milstein(
-                &p, hin, acceleration.acc, acceleration.collfreq,
-                hout_col, tol_col, wienarr, &sim->B_data,
-                &sim->plasma_data, &sim->mccc_data, rnd);
+            random_normal_simd(sim->random_data, 5*p.n_mrk, rnd);
+            mccc_gc_milstein(&p, hin, acceleration.acc, acceleration.collfreq,
+			     hout_col, tol_col, wienarr, &sim->B_data,
+                             &sim->plasma_data, &sim->mccc_data, rnd);
 
             /* Check whether time step was rejected */
-            #pragma omp simd
-            for(int i = 0; i < NSIMD; i++) {
+            GPU_PARALLEL_LOOP_ALL_LEVELS
+            for(int i = 0; i < p.n_mrk; i++) {
                 if(p.running[i] && hout_col[i] < 0){
                     p.running[i] = 0;
                     hnext[i] =  hout_col[i];
@@ -196,8 +202,8 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
                 &p, hin, hout_rfof, &rfof_mrk, &sim->rfof_data, &sim->B_data);
 
             /* Check whether time step was rejected */
-            #pragma omp simd
-            for(int i = 0; i < NSIMD; i++) {
+            GPU_PARALLEL_LOOP_ALL_LEVELS
+            for(int i = 0; i < p.n_mrk; i++) {
                 if(p.running[i] && hout_rfof[i] < 0){
                     p.running[i] = 0;
                     hnext[i] =  hout_rfof[i];
@@ -208,8 +214,8 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
         /**********************************************************************/
 
         cputime = A5_WTIME;
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             if(p.id[i] > 0 && !p.err[i]) {
                 /* Check other time step limitations */
                 if(hnext[i] > 0) {
@@ -290,11 +296,19 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
         diag_update_gc(&sim->diag_data, &sim->B_data, &p, &p0);
 
         /* Update number of running particles */
+#ifdef GPU
+        n_running = 0;
+        GPU_PARALLEL_LOOP_ALL_LEVELS_REDUCTION(n_running)
+        for(int i = 0; i < p.n_mrk; i++)
+        {
+            if(p.running[i] > 0) n_running++;
+        }
+#else
         n_running = particle_cycle_gc(pq, &p, &sim->B_data, cycle);
 
         /* Determine simulation time-step for new particles */
         #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        for(int i = 0; i <p.n_mrk; i++) {
             if(cycle[i] > 0) {
                 hin[i] = simulate_gc_adaptive_inidt(sim, &p, i);
                 acceleration.acc[i] = 1.0;
@@ -310,10 +324,23 @@ void simulate_gc_adaptive(particle_queue* pq, sim_data* sim) {
                 }
             }
         }
+#endif
     }
 
     /* All markers simulated! */
-
+#ifdef GPU
+    GPU_MAP_FROM_DEVICE(sim[0:1])
+    particle_onload_gc(&p);
+    n_running = particle_cycle_gc(pq, &p, &sim->B_data, cycle);
+    mccc_wiener_onload(wienarr,mrk_array_size);   
+#endif
+    free(cycle);
+    free(hin);
+    free(rnd);
+    free(hout_orb);
+    free(hout_col);
+    free(hout_rfof);
+    free(hnext);
     /* Deallocate rfof structs */
     if(sim->enable_icrh) {
         rfof_tear_down(&rfof_mrk);
@@ -387,7 +414,8 @@ void recalculate_acceleration(
 {
     real rz[2];
     real SAFETY_FACTOR = (float)sim->enable_ada / 1000.0;
-    for(int i = 0; i < NSIMD; i++) {
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(int i = 0; i < p->n_mrk; i++) {
         B_field_get_axis_rz(rz, &sim->B_data, p->phi[i]);
         int omp_crossed = ((p->z[i] - rz[1]) * (p0->z[i] - rz[1]) < 0) &&
             p->r[i] > rz[0];
@@ -419,4 +447,34 @@ void recalculate_acceleration(
             acc->orbittime[i] = 0;
         }
     }
+}
+
+/**
+ * @brief Allocates struct representing acceleration struc
+ *
+ * Size used for memory allocation is NSIMD for CPU run and the total number
+ * of particles for GPU.
+ *
+ * @param Acceleration struct to allocate
+ * @param nmrk the number of markers that the struct represents
+ */
+void acceleration_allocate(Acceleration* acceleration, int nmrk){
+  acceleration->acc       = malloc(nmrk * sizeof(acceleration->acc) );
+  acceleration->orbittime = malloc(nmrk * sizeof(acceleration->orbittime) );
+  acceleration->collfreq  = malloc(nmrk * sizeof(acceleration->collfreq) );
+  acceleration->cross     = malloc(nmrk * sizeof(acceleration->cross) );
+}
+/**
+ * @brief Offload acceleration struct to GPU.
+ *
+ * @param acceleration pointer to the acceleration struct to be offloaded.
+ */
+void acceleration_offload(Acceleration* acceleration, int mrk_array_size) {
+    GPU_MAP_TO_DEVICE(
+        acceleration[0:1],\
+        acceleration->acc       [0:mrk_array_size],\
+        acceleration->orbittime [0:mrk_array_size],\
+        acceleration->collfreq  [0:mrk_array_size],\
+        acceleration->cross     [0:mrk_array_size]
+    )
 }

--- a/src/simulate/simulate_gc_adaptive.h
+++ b/src/simulate/simulate_gc_adaptive.h
@@ -17,21 +17,25 @@ typedef struct {
 
 typedef struct {
     /** Acceleration factor. */
-    real acc[NSIMD];
+    real* acc;
 
     /** Orbit time [s]. */
-    real orbittime[NSIMD];
+    real* orbittime;
 
     /** Collision frequency [1/s]. */
-    real collfreq[NSIMD];
+    real* collfreq;
 
     /** Storage for OMP crossing data. */
-    Crossing cross[NSIMD];
+    Crossing* cross;
 } Acceleration;
 
 void recalculate_acceleration(
     Acceleration* acc, sim_data* sim, particle_simd_gc* p, particle_simd_gc* p0);
 
-void simulate_gc_adaptive(particle_queue* pq, sim_data* sim);
+void acceleration_allocate(Acceleration* acceleration, int nmrk);
+
+void acceleration_offload(Acceleration* acceleration, int nmrk);
+
+void simulate_gc_adaptive(particle_queue* pq, sim_data* sim, int mrk_array_size);
 
 #endif

--- a/src/simulate/simulate_gc_fixed.c
+++ b/src/simulate/simulate_gc_fixed.c
@@ -46,16 +46,16 @@ real simulate_gc_fixed_inidt(sim_data* sim, particle_simd_gc* p, int i);
  * @param pq particles to be simulated
  * @param sim simulation data
  */
-void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
-    int cycle[NSIMD]      __memalign__; /* Flag indigating whether a new marker
-                                           was initialized */
-    real hin[NSIMD]       __memalign__;  /* Time step given as an input into the
-                                           integrators. Almost always default.*/
-    real hin_default[NSIMD] __memalign__; /* The default fixed time step.     */
-    real hnext_recom[NSIMD]     __memalign__; /* Next time step, only used to
+void simulate_gc_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size) {
+    int* cycle = (int*) malloc(mrk_array_size*sizeof(int)); /* Flag indigating whether a new marker
+                                                              was initialized */
+    real* hin = (real*) malloc(mrk_array_size*sizeof(real));/* Time step given as an input into the
+                                                                integrators. Almost always default.*/
+    real* hin_default = (real*) malloc(mrk_array_size*sizeof(real)); /* The default fixed time step.     */
+    real* hnext_recom = (real*) malloc(mrk_array_size*sizeof(real)); /* Next time step, only used to
                                                 store the value when RFOF has
                                                 rejected a time step.         */
-    real hout_rfof[NSIMD] __memalign__; /* The time step that RFOF recommends.
+    real* hout_rfof = (real*) malloc(mrk_array_size*sizeof(real)); /* The time step that RFOF recommends.
                                             Small positive means that resonance
                                             is close, small negative means that
                                             the step failed because the marker
@@ -63,17 +63,16 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
                                             time step should be retaken with a
                                             smaller time step given by the
                                             negative of hout_rfof             */
-
-
     real cputime, cputime_last; // Global cpu time: recent and previous record
 
     particle_simd_gc p;  // This array holds current states
     particle_simd_gc p0; // This array stores previous states
-
+    particle_allocate_gc(&p, mrk_array_size);
+    particle_allocate_gc(&p0, mrk_array_size);
     rfof_marker rfof_mrk; // RFOF specific data
 
     /* Init dummy markers */
-    for(int i=0; i< NSIMD; i++) {
+    for(int i=0; i< mrk_array_size; i++) {
         p.id[i] = -1;
         p.running[i] = 0;
         hout_rfof[i] = DUMMY_TIMESTEP_VAL;
@@ -89,7 +88,7 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
 
     /* Determine simulation time-step */
     #pragma omp simd
-    for(int i = 0; i < NSIMD; i++) {
+    for(int i = 0; i < mrk_array_size; i++) {
         if(cycle[i] > 0) {
             hin_default[i] = simulate_gc_fixed_inidt(sim, &p, i);
             hin[i] = hin_default[i];
@@ -107,19 +106,23 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
      * - Check for end condition(s)
      * - Update diagnostics
      */
+    particle_offload_gc(&p);
+    particle_offload_gc(&p0);
+    real* rnd = (real*) malloc(5*mrk_array_size*sizeof(real));
+    GPU_MAP_TO_DEVICE(hin[0:mrk_array_size], rnd[0:5*mrk_array_size], hin_default[0:mrk_array_size], hnext_recom[0:mrk_array_size], hout_rfof[0:mrk_array_size])
     while(n_running > 0) {
 
         /* Store marker states */
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             particle_copy_gc(&p, i, &p0, i);
         }
 
         /*************************** Physics **********************************/
 
         /* Set time-step negative if tracing backwards in time */
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             if(sim->reverse_time) {
                 hin[i]  = -hin[i];
             }
@@ -139,8 +142,8 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
         }
 
         /* Switch sign of the time-step again if it was reverted earlier */
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             if(sim->reverse_time) {
                 hin[i]  = -hin[i];
             }
@@ -148,8 +151,7 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
 
         /* Euler-Maruyama method for collisions */
         if(sim->enable_clmbcol) {
-            real rnd[5*NSIMD];
-            random_normal_simd(&sim->random_data, 5*NSIMD, rnd);
+            random_normal_simd(sim->random_data, 5*p.n_mrk, rnd);
             mccc_gc_euler(&p, hin, &sim->B_data, &sim->plasma_data,
                           &sim->mccc_data, rnd);
         }
@@ -180,8 +182,8 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
 
         /* Update simulation and cpu times */
         cputime = A5_WTIME;
-        #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        GPU_PARALLEL_LOOP_ALL_LEVELS
+        for(int i = 0; i < p.n_mrk; i++) {
             if(hnext_recom[i] < 0) {
                 /* Screwed up big time (negative time-step only when RFOF
                     rejected) */
@@ -209,11 +211,21 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
         diag_update_gc(&sim->diag_data, &sim->B_data, &p, &p0);
 
         /* Update running particles */
+#ifdef GPU
+        n_running = 0;
+        GPU_PARALLEL_LOOP_ALL_LEVELS_REDUCTION(n_running)
+        for(int i = 0; i < p.n_mrk; i++)
+        {
+            if(p.running[i] > 0) n_running++;
+        }
+#else
         n_running = particle_cycle_gc(pq, &p, &sim->B_data, cycle);
-
+#endif
+	
+#ifndef GPU
         /* Determine simulation time-step */
         #pragma omp simd
-        for(int i = 0; i < NSIMD; i++) {
+        for(int i = 0; i < p.n_mrk; i++) {
             if(cycle[i] > 0) {
                 hin[i] = simulate_gc_fixed_inidt(sim, &p, i);
                 if(sim->enable_icrh) {
@@ -222,10 +234,19 @@ void simulate_gc_fixed(particle_queue* pq, sim_data* sim) {
                 }
             }
         }
+#endif
 
     }
 
     /* All markers simulated! */
+#ifdef GPU
+    GPU_MAP_FROM_DEVICE(sim[0:1])
+    particle_onload_gc(&p);
+    n_running = particle_cycle_gc(pq, &p, &sim->B_data, cycle);
+#endif
+    free(cycle);
+    free(hin);
+    free(rnd);
 
     /* Deallocate rfof structs */
     if(sim->enable_icrh) {

--- a/src/simulate/simulate_gc_fixed.h
+++ b/src/simulate/simulate_gc_fixed.h
@@ -9,6 +9,6 @@
 #include "../simulate.h"
 #include "../particle.h"
 
-void simulate_gc_fixed(particle_queue* pq, sim_data* sim);
+void simulate_gc_fixed(particle_queue* pq, sim_data* sim, int mrk_array_size);
 
 #endif

--- a/src/simulate/step/step_gc_cashkarp.c
+++ b/src/simulate/step/step_gc_cashkarp.c
@@ -38,8 +38,9 @@ void step_gc_cashkarp(particle_simd_gc* p, real* h, real* hnext, real tol,
 
     int i;
     /* Following loop will be executed simultaneously for all i */
-    #pragma omp simd aligned(h, hnext : 64)
-    for(i = 0; i < NSIMD; i++) {
+    GPU_DATA_IS_MAPPED(h[0:p->n_mrk],hnext[0:p->n_mrk])
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(i = 0; i < p->n_mrk; i++) {
         if(p->running[i]) {
             a5err errflag = 0;
 
@@ -349,8 +350,9 @@ void step_gc_cashkarp_mhd(
 
     int i;
     /* Following loop will be executed simultaneously for all i */
-#pragma omp simd aligned(h, hnext : 64)
-    for(i = 0; i < NSIMD; i++) {
+    GPU_DATA_IS_MAPPED(h[0:p->n_mrk],hnext[0:p->n_mrk])
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(i = 0; i < p->n_mrk; i++) {
         if(p->running[i]) {
             a5err errflag = 0;
 

--- a/src/simulate/step/step_gc_rk4.c
+++ b/src/simulate/step/step_gc_rk4.c
@@ -36,8 +36,9 @@ void step_gc_rk4(particle_simd_gc* p, real* h, B_field_data* Bdata,
 
     int i;
     /* Following loop will be executed simultaneously for all i */
-    #pragma omp simd aligned(h : 64)
-    for(i = 0; i < NSIMD; i++) {
+    GPU_DATA_IS_MAPPED(h[0:p->n_mrk])
+    GPU_PARALLEL_LOOP_ALL_LEVELS
+    for(i = 0; i < p->n_mrk; i++) {
         if(p->running[i]) {
             a5err errflag = 0;
 

--- a/src/spline/interp.h
+++ b/src/spline/interp.h
@@ -177,6 +177,11 @@ int interp3Dcomp_setup(interp3D_data* str, real* f,
                        real x_min, real x_max, real y_min, real y_max,
                        real z_min, real z_max);
 
+/* Precondition check for interp3Dcomp_eval_f3() and interp3Dcomp_eval_df3(),
+   to be called where the splines are initialized. */
+int interp3Dcomp_same_grid(interp3D_data* str0, interp3D_data* str1,
+                           interp3D_data* str2);
+
 GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp1Dcomp_eval_f(real* f, interp1D_data* str, real x);
 DECLARE_TARGET_END
@@ -186,6 +191,10 @@ DECLARE_TARGET_END
 GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp3Dcomp_eval_f(real* f, interp3D_data* str,
                          real x, real y, real z);
+DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str0, str1, str2)
+a5err interp3Dcomp_eval_f3(real* f, interp3D_data* str0, interp3D_data* str1,
+                           interp3D_data* str2, real x, real y, real z);
 DECLARE_TARGET_END
 
 DECLARE_TARGET_SIMD_UNIFORM(str)
@@ -205,6 +214,11 @@ DECLARE_TARGET_END
 GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
                            real x, real y, real z);
+DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str0, str1, str2)
+a5err interp3Dcomp_eval_df3(real* f_df, interp3D_data* str0,
+                            interp3D_data* str1, interp3D_data* str2,
+                            real x, real y, real z);
 DECLARE_TARGET_END
 GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp3Dcomp_eval_ddf(real* f_df, interp3D_data* str,

--- a/src/spline/interp.h
+++ b/src/spline/interp.h
@@ -206,6 +206,10 @@ GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
                            real x, real y, real z);
 DECLARE_TARGET_END
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
+a5err interp3Dcomp_eval_ddf(real* f_df, interp3D_data* str,
+                            real x, real y, real z);
+DECLARE_TARGET_END
 
 DECLARE_TARGET_SIMD_UNIFORM(str)
 a5err interp1Dexpl_eval_df(real* f_df, interp1D_data* str, real x);

--- a/src/spline/interp3Dcomp.c
+++ b/src/spline/interp3Dcomp.c
@@ -272,6 +272,50 @@ int interp3Dcomp_setup(interp3D_data* str, real* f,
 }
 
 /**
+ * @brief Check that three tricubic splines are defined on the same grid
+ *
+ * interp3Dcomp_eval_f3() and interp3Dcomp_eval_df3() take all grid metadata
+ * from their first spline, so they may only be used on splines whose grids are
+ * identical. This function verifies that precondition. It is meant to be called
+ * once where the splines are initialized, so that the evaluators themselves,
+ * which run on the device for every marker and every time step, need not.
+ *
+ * The grid bounds and spacings are compared exactly, which is what is wanted:
+ * the splines are required to be on the same grid, not on grids that happen to
+ * agree to some tolerance.
+ *
+ * @param str0 first spline, the one whose grid the others must match
+ * @param str1 second spline
+ * @param str2 third spline
+ *
+ * @return one if all three are defined on the same grid and zero otherwise
+ */
+int interp3Dcomp_same_grid(interp3D_data* str0, interp3D_data* str1,
+                           interp3D_data* str2) {
+    interp3D_data* str[2] = {str1, str2};
+    for(int i = 0; i < 2; i++) {
+        if(   str[i]->n_x    != str0->n_x
+           || str[i]->n_y    != str0->n_y
+           || str[i]->n_z    != str0->n_z
+           || str[i]->bc_x   != str0->bc_x
+           || str[i]->bc_y   != str0->bc_y
+           || str[i]->bc_z   != str0->bc_z
+           || str[i]->x_min  != str0->x_min
+           || str[i]->x_max  != str0->x_max
+           || str[i]->x_grid != str0->x_grid
+           || str[i]->y_min  != str0->y_min
+           || str[i]->y_max  != str0->y_max
+           || str[i]->y_grid != str0->y_grid
+           || str[i]->z_min  != str0->z_min
+           || str[i]->z_max  != str0->z_max
+           || str[i]->z_grid != str0->z_grid ) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/**
  * @brief Spline basis polynomials and cell indices for a tricubic evaluation
  *
  * These quantities depend on the evaluation point and on the grid only, not on
@@ -534,6 +578,46 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
 
     if(!err) {
         interp3Dcomp_eval_comp_f(f, str, &b);
+    }
+
+    return err;
+}
+
+/**
+ * @brief Evaluate three same-grid 3D scalar fields at a single point
+ *
+ * This function evaluates the interpolated values of three 3D scalar fields
+ * whose tricubic splines are defined on one and the same grid. The periodic
+ * wrapping, the cell search and the spline basis polynomials are common to the
+ * three components and are evaluated once instead of three times; each
+ * component's coefficient sum is then evaluated by the same routine that
+ * interp3Dcomp_eval_f() uses, so the arithmetic per component is unchanged.
+ *
+ * All grid metadata is taken from str0, and str1 and str2 must be defined on
+ * that same grid, i.e. interp3Dcomp_same_grid() must hold for the three. That
+ * check belongs where the splines are initialized; it is not repeated here
+ * because this function is on the device hot path.
+ *
+ * @param f array of length 3 in which to place the evaluated values
+ * @param str0 data struct for the first component
+ * @param str1 data struct for the second component, same grid as str0
+ * @param str2 data struct for the third component, same grid as str0
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param z z-coordinate
+ *
+ * @return zero on success and one if (x,y,z) point is outside the grid.
+ */
+a5err interp3Dcomp_eval_f3(real* f, interp3D_data* str0, interp3D_data* str1,
+                           interp3D_data* str2, real x, real y, real z) {
+
+    interp3Dcomp_basis_f b;
+    int err = interp3Dcomp_eval_basis_f(&b, str0, x, y, z);
+
+    if(!err) {
+        interp3Dcomp_eval_comp_f(&f[0], str0, &b);
+        interp3Dcomp_eval_comp_f(&f[1], str1, &b);
+        interp3Dcomp_eval_comp_f(&f[2], str2, &b);
     }
 
     return err;
@@ -1117,6 +1201,49 @@ a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
 
     if(!err) {
         interp3Dcomp_eval_comp_df(f_df, str, &b);
+    }
+
+    return err;
+}
+
+/**
+ * @brief Evaluate three same-grid 3D scalar fields and their 1st derivatives
+ *
+ * As interp3Dcomp_eval_f3(), but each component also yields its three first
+ * derivatives. The twelve evaluated values are returned as three consecutive
+ * blocks of four, one block per component, each laid out as the output of
+ * interp3Dcomp_eval_df():
+ * - f_df[4*i+0] = f
+ * - f_df[4*i+1] = f_x
+ * - f_df[4*i+2] = f_y
+ * - f_df[4*i+3] = f_z
+ *
+ * All grid metadata is taken from str0, and str1 and str2 must be defined on
+ * that same grid, i.e. interp3Dcomp_same_grid() must hold for the three. That
+ * check belongs where the splines are initialized; it is not repeated here
+ * because this function is on the device hot path.
+ *
+ * @param f_df array of length 12 in which to place the evaluated values
+ * @param str0 data struct for the first component
+ * @param str1 data struct for the second component, same grid as str0
+ * @param str2 data struct for the third component, same grid as str0
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param z z-coordinate
+ *
+ * @return zero on success and one if (x,y,z) point is outside the grid.
+ */
+a5err interp3Dcomp_eval_df3(real* f_df, interp3D_data* str0,
+                            interp3D_data* str1, interp3D_data* str2,
+                            real x, real y, real z) {
+
+    interp3Dcomp_basis_df b;
+    int err = interp3Dcomp_eval_basis_df(&b, str0, x, y, z);
+
+    if(!err) {
+        interp3Dcomp_eval_comp_df(&f_df[0], str0, &b);
+        interp3Dcomp_eval_comp_df(&f_df[4], str1, &b);
+        interp3Dcomp_eval_comp_df(&f_df[8], str2, &b);
     }
 
     return err;

--- a/src/spline/interp3Dcomp.c
+++ b/src/spline/interp3Dcomp.c
@@ -272,12 +272,43 @@ int interp3Dcomp_setup(interp3D_data* str, real* f,
 }
 
 /**
- * @brief Evaluate interpolated value of 3D scalar field
+ * @brief Spline basis polynomials and cell indices for a tricubic evaluation
  *
- * This function evaluates the interpolated value of a 3D scalar field using
- * tricubic spline interpolation coefficients of the compact form.
+ * These quantities depend on the evaluation point and on the grid only, not on
+ * the spline coefficients. Splines defined on one and the same grid therefore
+ * share them, which is what lets the coefficient sum be written just once.
+ */
+typedef struct {
+    real dx;   /**< Normalized x coordinate in the current cell  */
+    real dxi;  /**< 1 - dx                                       */
+    real dx3;  /**< dx^3 - dx                                    */
+    real dxi3; /**< dxi^3 - dxi                                  */
+    real xg2;  /**< Square of the x grid interval                */
+    real dy;   /**< Normalized y coordinate in the current cell  */
+    real dyi;  /**< 1 - dy                                       */
+    real dy3;  /**< dy^3 - dy                                    */
+    real dyi3; /**< dyi^3 - dyi                                  */
+    real yg2;  /**< Square of the y grid interval                */
+    real dz;   /**< Normalized z coordinate in the current cell  */
+    real dzi;  /**< 1 - dz                                       */
+    real dz3;  /**< dz^3 - dz                                    */
+    real dzi3; /**< dzi^3 - dzi                                  */
+    real zg2;  /**< Square of the z grid interval                */
+    int n;     /**< Index jump to the current cell               */
+    int x1;    /**< Index jump one x forward                     */
+    int y1;    /**< Index jump one y forward                     */
+    int z1;    /**< Index jump one z forward                     */
+} interp3Dcomp_basis_f;
+
+/**
+ * @brief Evaluate the tricubic spline basis at a given point
  *
- * @param f variable in which to place the evaluated value
+ * Wraps periodic coordinates into the grid, locates the cell that contains
+ * (x,y,z) and evaluates the basis polynomials and the index jumps needed by
+ * interp3Dcomp_eval_comp_f(). Only grid metadata is read from str, so the
+ * result is valid for every spline that is defined on that same grid.
+ *
+ * @param b basis struct in which to place the evaluated values
  * @param str data struct for data interpolation
  * @param x x-coordinate
  * @param y y-coordinate
@@ -285,7 +316,10 @@ int interp3Dcomp_setup(interp3D_data* str, real* f,
  *
  * @return zero on success and one if (x,y,z) point is outside the grid.
  */
-a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
+static inline FORCE_INLINE
+int interp3Dcomp_eval_basis_f(interp3Dcomp_basis_f* b, interp3D_data* str,
+                              real x, real y, real z) {
 
     /* Make sure periodic coordinates are within [min, max] region. */
     if(str->bc_x == PERIODICBC) {
@@ -359,7 +393,65 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
         err = 1;
     }
 
-    if(!err) {
+    b->dx   = dx;
+    b->dxi  = dxi;
+    b->dx3  = dx3;
+    b->dxi3 = dxi3;
+    b->xg2  = xg2;
+    b->dy   = dy;
+    b->dyi  = dyi;
+    b->dy3  = dy3;
+    b->dyi3 = dyi3;
+    b->yg2  = yg2;
+    b->dz   = dz;
+    b->dzi  = dzi;
+    b->dz3  = dz3;
+    b->dzi3 = dzi3;
+    b->zg2  = zg2;
+    b->n    = n;
+    b->x1   = x1;
+    b->y1   = y1;
+    b->z1   = z1;
+
+    return err;
+}
+DECLARE_TARGET_END
+
+/**
+ * @brief Evaluate the tricubic sum of one set of spline coefficients
+ *
+ * Sums the compact-form coefficients of str against the basis in b. The sum is
+ * the sole place where the tricubic interpolation formula is written; both the
+ * single-component and the three-component evaluators call this function.
+ *
+ * @param f variable in which to place the evaluated value
+ * @param str data struct holding the coefficients to sum
+ * @param b spline basis from interp3Dcomp_eval_basis_f()
+ */
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
+static inline FORCE_INLINE
+void interp3Dcomp_eval_comp_f(real* f, interp3D_data* str,
+                              const interp3Dcomp_basis_f* b) {
+
+    real dx   = b->dx;
+    real dxi  = b->dxi;
+    real dx3  = b->dx3;
+    real dxi3 = b->dxi3;
+    real xg2  = b->xg2;
+    real dy   = b->dy;
+    real dyi  = b->dyi;
+    real dy3  = b->dy3;
+    real dyi3 = b->dyi3;
+    real yg2  = b->yg2;
+    real dz   = b->dz;
+    real dzi  = b->dzi;
+    real dz3  = b->dz3;
+    real dzi3 = b->dzi3;
+    real zg2  = b->zg2;
+    int n  = b->n;
+    int x1 = b->x1;
+    int y1 = b->y1;
+    int z1 = b->z1;
 
         /* Evaluate spline value */
         *f = (
@@ -418,26 +510,16 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
                 +dz3*(
                     dxi3*(dyi3*str->c[n+z1+7]+dy3*str->c[n+y1+z1+7])
                     +dx3*(dyi3*str->c[n+x1+z1+7]+dy3*str->c[n+y1+z1+x1+7])));
-
-    }
-
-    return err;
 }
+DECLARE_TARGET_END
 
 /**
- * @brief Evaluate interpolated value of 3D field and 1st and 1st derivatives
+ * @brief Evaluate interpolated value of 3D scalar field
  *
- * This function evaluates the interpolated value of a 3D scalar field and
- * its 1st derivatives using bicubic spline interpolation coefficients
- * of the compact form.
+ * This function evaluates the interpolated value of a 3D scalar field using
+ * tricubic spline interpolation coefficients of the compact form.
  *
- * The evaluated  values are returned in an array with following elements:
- * - f_df[0] = f
- * - f_df[1] = f_x
- * - f_df[2] = f_y
- * - f_df[3] = f_z
- *
- * @param f_df array in which to place the evaluated values
+ * @param f variable in which to place the evaluated value
  * @param str data struct for data interpolation
  * @param x x-coordinate
  * @param y y-coordinate
@@ -445,8 +527,79 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
  *
  * @return zero on success and one if (x,y,z) point is outside the grid.
  */
-a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
-                         real x, real y, real z) {
+a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
+
+    interp3Dcomp_basis_f b;
+    int err = interp3Dcomp_eval_basis_f(&b, str, x, y, z);
+
+    if(!err) {
+        interp3Dcomp_eval_comp_f(f, str, &b);
+    }
+
+    return err;
+}
+
+/**
+ * @brief Spline basis polynomials and cell indices for a tricubic evaluation
+ *        of the value and the first derivatives
+ *
+ * As interp3Dcomp_basis_f, but also carries the derivatives of the basis
+ * polynomials and the grid intervals and their inverses.
+ */
+typedef struct {
+    real dx;     /**< Normalized x coordinate in the current cell  */
+    real dx3;    /**< dx^3 - dx                                    */
+    real dx3dx;  /**< Derivative of dx3 with respect to dx         */
+    real dxi;    /**< 1 - dx                                       */
+    real dxi3;   /**< dxi^3 - dxi                                  */
+    real dxi3dx; /**< Derivative of dxi3 with respect to dx        */
+    real xg;     /**< x grid interval                              */
+    real xg2;    /**< Square of the x grid interval                */
+    real xgi;    /**< Inverse of the x grid interval               */
+    real dy;     /**< Normalized y coordinate in the current cell  */
+    real dy3;    /**< dy^3 - dy                                    */
+    real dy3dy;  /**< Derivative of dy3 with respect to dy         */
+    real dyi;    /**< 1 - dy                                       */
+    real dyi3;   /**< dyi^3 - dyi                                  */
+    real dyi3dy; /**< Derivative of dyi3 with respect to dy        */
+    real yg;     /**< y grid interval                              */
+    real yg2;    /**< Square of the y grid interval                */
+    real ygi;    /**< Inverse of the y grid interval               */
+    real dz;     /**< Normalized z coordinate in the current cell  */
+    real dz3;    /**< dz^3 - dz                                    */
+    real dz3dz;  /**< Derivative of dz3 with respect to dz         */
+    real dzi;    /**< 1 - dz                                       */
+    real dzi3;   /**< dzi^3 - dzi                                  */
+    real dzi3dz; /**< Derivative of dzi3 with respect to dz        */
+    real zg;     /**< z grid interval                              */
+    real zg2;    /**< Square of the z grid interval                */
+    real zgi;    /**< Inverse of the z grid interval               */
+    int n;       /**< Index jump to the current cell               */
+    int x1;      /**< Index jump one x forward                     */
+    int y1;      /**< Index jump one y forward                     */
+    int z1;      /**< Index jump one z forward                     */
+} interp3Dcomp_basis_df;
+
+/**
+ * @brief Evaluate the tricubic spline basis and its derivatives
+ *
+ * Wraps periodic coordinates into the grid, locates the cell that contains
+ * (x,y,z) and evaluates the basis polynomials, their derivatives and the index
+ * jumps needed by interp3Dcomp_eval_comp_df(). Only grid metadata is read from
+ * str, so the result is valid for every spline defined on that same grid.
+ *
+ * @param b basis struct in which to place the evaluated values
+ * @param str data struct for data interpolation
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param z z-coordinate
+ *
+ * @return zero on success and one if (x,y,z) point is outside the grid.
+ */
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
+static inline FORCE_INLINE
+int interp3Dcomp_eval_basis_df(interp3Dcomp_basis_df* b, interp3D_data* str,
+                               real x, real y, real z) {
 
     /* Make sure periodic coordinates are within [min, max] region. */
     if(str->bc_x == PERIODICBC) {
@@ -532,7 +685,95 @@ a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
         err = 1;
     }
 
-    if(!err) {
+    b->dx     = dx;
+    b->dx3    = dx3;
+    b->dx3dx  = dx3dx;
+    b->dxi    = dxi;
+    b->dxi3   = dxi3;
+    b->dxi3dx = dxi3dx;
+    b->xg     = xg;
+    b->xg2    = xg2;
+    b->xgi    = xgi;
+    b->dy     = dy;
+    b->dy3    = dy3;
+    b->dy3dy  = dy3dy;
+    b->dyi    = dyi;
+    b->dyi3   = dyi3;
+    b->dyi3dy = dyi3dy;
+    b->yg     = yg;
+    b->yg2    = yg2;
+    b->ygi    = ygi;
+    b->dz     = dz;
+    b->dz3    = dz3;
+    b->dz3dz  = dz3dz;
+    b->dzi    = dzi;
+    b->dzi3   = dzi3;
+    b->dzi3dz = dzi3dz;
+    b->zg     = zg;
+    b->zg2    = zg2;
+    b->zgi    = zgi;
+    b->n      = n;
+    b->x1     = x1;
+    b->y1     = y1;
+    b->z1     = z1;
+
+    return err;
+}
+DECLARE_TARGET_END
+
+/**
+ * @brief Evaluate the tricubic sums of one set of spline coefficients
+ *
+ * Sums the compact-form coefficients of str against the basis in b to give the
+ * value and the three first derivatives:
+ * - f_df[0] = f
+ * - f_df[1] = f_x
+ * - f_df[2] = f_y
+ * - f_df[3] = f_z
+ *
+ * The sums are the sole place where these formulae are written; both the
+ * single-component and the three-component evaluators call this function.
+ *
+ * @param f_df array in which to place the evaluated values
+ * @param str data struct holding the coefficients to sum
+ * @param b spline basis from interp3Dcomp_eval_basis_df()
+ */
+GPU_DECLARE_TARGET_SIMD_UNIFORM(str)
+static inline FORCE_INLINE
+void interp3Dcomp_eval_comp_df(real* f_df, interp3D_data* str,
+                               const interp3Dcomp_basis_df* b) {
+
+    real dx     = b->dx;
+    real dx3    = b->dx3;
+    real dx3dx  = b->dx3dx;
+    real dxi    = b->dxi;
+    real dxi3   = b->dxi3;
+    real dxi3dx = b->dxi3dx;
+    real xg     = b->xg;
+    real xg2    = b->xg2;
+    real xgi    = b->xgi;
+    real dy     = b->dy;
+    real dy3    = b->dy3;
+    real dy3dy  = b->dy3dy;
+    real dyi    = b->dyi;
+    real dyi3   = b->dyi3;
+    real dyi3dy = b->dyi3dy;
+    real yg     = b->yg;
+    real yg2    = b->yg2;
+    real ygi    = b->ygi;
+    real dz     = b->dz;
+    real dz3    = b->dz3;
+    real dz3dz  = b->dz3dz;
+    real dzi    = b->dzi;
+    real dzi3   = b->dzi3;
+    real dzi3dz = b->dzi3dz;
+    real zg     = b->zg;
+    real zg2    = b->zg2;
+    real zgi    = b->zgi;
+    int n  = b->n;
+    int x1 = b->x1;
+    int y1 = b->y1;
+    int z1 = b->z1;
 
         /* Fetch coefficients explicitly to fetch those that are adjacent
            subsequently and to store in temporary variables coefficients that
@@ -844,6 +1085,38 @@ a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
             +dz3dz*(
                 dxi3*(dyi3*c1007+dy3*c1107)
                 +dx3*(dyi3*c1017+dy3*c1117)));
+}
+DECLARE_TARGET_END
+
+/**
+ * @brief Evaluate interpolated value of 3D field and 1st and 1st derivatives
+ *
+ * This function evaluates the interpolated value of a 3D scalar field and
+ * its 1st derivatives using bicubic spline interpolation coefficients
+ * of the compact form.
+ *
+ * The evaluated  values are returned in an array with following elements:
+ * - f_df[0] = f
+ * - f_df[1] = f_x
+ * - f_df[2] = f_y
+ * - f_df[3] = f_z
+ *
+ * @param f_df array in which to place the evaluated values
+ * @param str data struct for data interpolation
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param z z-coordinate
+ *
+ * @return zero on success and one if (x,y,z) point is outside the grid.
+ */
+a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
+                         real x, real y, real z) {
+
+    interp3Dcomp_basis_df b;
+    int err = interp3Dcomp_eval_basis_df(&b, str, x, y, z);
+
+    if(!err) {
+        interp3Dcomp_eval_comp_df(f_df, str, &b);
     }
 
     return err;

--- a/src/spline/interp3Dcomp.c
+++ b/src/spline/interp3Dcomp.c
@@ -425,6 +425,431 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
 }
 
 /**
+ * @brief Evaluate interpolated value of 3D field and 1st and 1st derivatives
+ *
+ * This function evaluates the interpolated value of a 3D scalar field and
+ * its 1st derivatives using bicubic spline interpolation coefficients
+ * of the compact form.
+ *
+ * The evaluated  values are returned in an array with following elements:
+ * - f_df[0] = f
+ * - f_df[1] = f_x
+ * - f_df[2] = f_y
+ * - f_df[3] = f_z
+ *
+ * @param f_df array in which to place the evaluated values
+ * @param str data struct for data interpolation
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param z z-coordinate
+ *
+ * @return zero on success and one if (x,y,z) point is outside the grid.
+ */
+a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
+                         real x, real y, real z) {
+
+    /* Make sure periodic coordinates are within [min, max] region. */
+    if(str->bc_x == PERIODICBC) {
+        x = fmod(x - str->x_min, str->x_max - str->x_min) + str->x_min;
+        x = x + (x < str->x_min) * (str->x_max - str->x_min);
+    }
+    if(str->bc_y == PERIODICBC) {
+        y = fmod(y - str->y_min, str->y_max - str->y_min) + str->y_min;
+        y = y + (y < str->y_min) * (str->y_max - str->y_min);
+    }
+    if(str->bc_z == PERIODICBC) {
+        z = fmod(z - str->z_min, str->z_max - str->z_min) + str->z_min;
+        z = z + (z < str->z_min) * (str->z_max - str->z_min);
+    }
+
+    /* Index for x variable. The -1 needed at exactly grid end. */
+    int i_x     = (x - str->x_min) / str->x_grid - 1*(x==str->x_max);
+    /* Normalized x coordinate in current cell */
+    real dx     = ( x - (str->x_min + i_x*str->x_grid) ) / str->x_grid;
+    /* Helper variables */
+    real dx3    = dx*dx*dx - dx;
+    real dx3dx  = 3*dx*dx - 1.0;
+    real dxi    = 1.0 - dx;
+    real dxi3   = dxi*dxi*dxi - dxi;
+    real dxi3dx = -3*dxi*dxi + 1.0;
+    real xg     = str->x_grid;
+    real xg2    = xg*xg;
+    real xgi    = 1.0 / xg;
+
+    /* Index for y variable. The -1 needed at exactly grid end. */
+    int i_y     = (y - str->y_min) / str->y_grid - 1*(y==str->y_max);
+    /* Normalized y coordinate in current cell */
+    real dy     = ( y - (str->y_min + i_y*str->y_grid) ) / str->y_grid;
+    /* Helper variables */
+    real dy3    = dy*dy*dy-dy;
+    real dy3dy  = 3*dy*dy - 1.0;
+    real dyi    = 1.0 - dy;
+    real dyi3   = dyi*dyi*dyi - dyi;
+    real dyi3dy = -3*dyi*dyi + 1.0;
+    real yg     = str->y_grid;
+    real yg2    = yg*yg;
+    real ygi    = 1.0 / yg;
+
+    /* Index for z variable. The -1 needed at exactly grid end. */
+    int i_z     = (z - str->z_min) / str->z_grid - 1*(z==str->z_max);
+    /* Normalized z coordinate in current cell */
+    real dz     = ( z - (str->z_min + i_z*str->z_grid) ) / str->z_grid;
+    /* Helper variables */
+    real dz3    = dz*dz*dz - dz;
+    real dz3dz  = 3*dz*dz - 1.0;
+    real dzi    = 1.0 - dz;
+    real dzi3   = dzi*dzi*dzi - dzi;
+    real dzi3dz = -3*dzi*dzi + 1.0;
+    real zg     = str->z_grid;
+    real zg2    = zg*zg;
+    real zgi    = 1.0 / zg;
+
+    /* Index jump to cell */
+    int n  = i_z*str->n_y*str->n_x*8 + i_y*str->n_x*8 + i_x*8;
+    int x1 = 8;                   /* Index jump one x forward */
+    int y1 = str->n_x*8;          /* Index jump one y forward */
+    int z1 = str->n_y*str->n_x*8; /* Index jump one z forward */
+
+    int err = 0;
+
+    /* Enforce periodic BC or check that the coordinate is within the domain. */
+    if( str->bc_x == PERIODICBC && i_x == str->n_x-1 ) {
+        x1 = -(str->n_x-1)*x1;
+    }
+    else if( str->bc_x == NATURALBC && !(x >= str->x_min && x <= str->x_max) ) {
+        err = 1;
+    }
+    if( str->bc_y == PERIODICBC && i_y == str->n_y-1 ) {
+        y1 = -(str->n_y-1)*y1;
+    }
+    else if( str->bc_y == NATURALBC && !(y >= str->y_min && y <= str->y_max) ) {
+        err = 1;
+    }
+    if( str->bc_z == PERIODICBC && i_z == str->n_z-1 ) {
+        z1 = -(str->n_z-1)*z1;
+    }
+    else if( str->bc_z == NATURALBC && !(z >= str->z_min && z <= str->z_max) ) {
+        err = 1;
+    }
+
+    if(!err) {
+
+        /* Fetch coefficients explicitly to fetch those that are adjacent
+           subsequently and to store in temporary variables coefficients that
+           will be used multiple times. This is to decrease computational time,
+           by exploiting simultaneous extraction of adjacent memory and by
+           avoiding going through the long str->c array repeatedly. */
+        real c0000 = str->c[n+0];
+        real c0001 = str->c[n+1];
+        real c0002 = str->c[n+2];
+        real c0003 = str->c[n+3];
+        real c0004 = str->c[n+4];
+        real c0005 = str->c[n+5];
+        real c0006 = str->c[n+6];
+        real c0007 = str->c[n+7];
+
+        real c0010 = str->c[n+x1+0];
+        real c0011 = str->c[n+x1+1];
+        real c0012 = str->c[n+x1+2];
+        real c0013 = str->c[n+x1+3];
+        real c0014 = str->c[n+x1+4];
+        real c0015 = str->c[n+x1+5];
+        real c0016 = str->c[n+x1+6];
+        real c0017 = str->c[n+x1+7];
+
+        real c0100 = str->c[n+y1+0];
+        real c0101 = str->c[n+y1+1];
+        real c0102 = str->c[n+y1+2];
+        real c0103 = str->c[n+y1+3];
+        real c0104 = str->c[n+y1+4];
+        real c0105 = str->c[n+y1+5];
+        real c0106 = str->c[n+y1+6];
+        real c0107 = str->c[n+y1+7];
+
+        real c1000 = str->c[n+z1+0];
+        real c1001 = str->c[n+z1+1];
+        real c1002 = str->c[n+z1+2];
+        real c1003 = str->c[n+z1+3];
+        real c1004 = str->c[n+z1+4];
+        real c1005 = str->c[n+z1+5];
+        real c1006 = str->c[n+z1+6];
+        real c1007 = str->c[n+z1+7];
+
+        real c0110 = str->c[n+y1+x1+0];
+        real c0111 = str->c[n+y1+x1+1];
+        real c0112 = str->c[n+y1+x1+2];
+        real c0113 = str->c[n+y1+x1+3];
+        real c0114 = str->c[n+y1+x1+4];
+        real c0115 = str->c[n+y1+x1+5];
+        real c0116 = str->c[n+y1+x1+6];
+        real c0117 = str->c[n+y1+x1+7];
+
+        real c1010 = str->c[n+z1+x1+0];
+        real c1011 = str->c[n+z1+x1+1];
+        real c1012 = str->c[n+z1+x1+2];
+        real c1013 = str->c[n+z1+x1+3];
+        real c1014 = str->c[n+z1+x1+4];
+        real c1015 = str->c[n+z1+x1+5];
+        real c1016 = str->c[n+z1+x1+6];
+        real c1017 = str->c[n+z1+x1+7];
+
+        real c1100 = str->c[n+z1+y1+0];
+        real c1101 = str->c[n+z1+y1+1];
+        real c1102 = str->c[n+z1+y1+2];
+        real c1103 = str->c[n+z1+y1+3];
+        real c1104 = str->c[n+z1+y1+4];
+        real c1105 = str->c[n+z1+y1+5];
+        real c1106 = str->c[n+z1+y1+6];
+        real c1107 = str->c[n+z1+y1+7];
+
+        real c1110 = str->c[n+z1+y1+x1+0];
+        real c1111 = str->c[n+z1+y1+x1+1];
+        real c1112 = str->c[n+z1+y1+x1+2];
+        real c1113 = str->c[n+z1+y1+x1+3];
+        real c1114 = str->c[n+z1+y1+x1+4];
+        real c1115 = str->c[n+z1+y1+x1+5];
+        real c1116 = str->c[n+z1+y1+x1+6];
+        real c1117 = str->c[n+z1+y1+x1+7];
+
+        /* Evaluate spline values */
+
+        /* f */
+        f_df[0] = (
+               dzi*(
+                   dxi*(dyi*c0000+dy*c0100)
+                   +dx*(dyi*c0010+dy*c0110))
+               +dz*(
+                   dxi*(dyi*c1000+dy*c1100)
+                   +dx*(dyi*c1010+dy*c1110)))
+        +xg2/6*(
+            dzi*(
+                dxi3*(dyi*c0001+dy*c0101)
+                +dx3*(dyi*c0011+dy*c0111))
+            +dz*(
+                dxi3*(dyi*c1001+dy*c1101)
+                +dx3*(dyi*c1011+dy*c1111)))
+        +yg2/6*(
+            dzi*(
+                dxi*(dyi3*c0002+dy3*c0102)
+                +dx*(dyi3*c0012+dy3*c0112))
+            +dz*(
+                dxi*(dyi3*c1002+dy3*c1102)
+                +dx*(dyi3*c1012+dy3*c1112)))
+        +zg2/6*(
+            dzi3*(
+                dxi*(dyi*c0003+dy*c0103)
+                +dx*(dyi*c0013+dy*c0113))
+            +dz3*(
+                dxi*(dyi*c1003+dy*c1103)
+                +dx*(dyi*c1013+dy*c1113)))
+        +xg2*yg2/36*(
+            dzi*(
+                dxi3*(dyi3*c0004+dy3*c0104)
+                +dx3*(dyi3*c0014+dy3*c0114))
+            +dz*(
+                dxi3*(dyi3*c1004+dy3*c1104)
+                +dx3*(dyi3*c1014+dy3*c1114)))
+        +xg2*zg2/36*(
+            dzi3*(
+                dxi3*(dyi*c0005+dy*c0105)
+                +dx3*(dyi*c0015+dy*c0115))
+            +dz3*(
+                dxi3*(dyi*c1005+dy*c1105)
+                +dx3*(dyi*c1015+dy*c1115)))
+        +yg2*zg2/36*(
+            dzi3*(
+                dxi*(dyi3*c0006+dy3*c0106)
+                +dx*(dyi3*c0016+dy3*c0116))
+            +dz3*(
+                dxi*(dyi3*c1006+dy3*c1106)
+                +dx*(dyi3*c1016+dy3*c1116)))
+        +xg2*yg2*zg2/216*(
+            dzi3*(
+                dxi3*(dyi3*c0007+dy3*c0107)
+                +dx3*(dyi3*c0017+dy3*c0117))
+            +dz3*(
+                dxi3*(dyi3*c1007+dy3*c1107)
+                +dx3*(dyi3*c1017+dy3*c1117)));
+
+    /* df/dx */
+    f_df[1] = xgi*(
+        dzi*(
+            -(dyi*c0000+dy*c0100)
+            +(dyi*c0010+dy*c0110))
+        +dz*(
+            -(dyi*c1000+dy*c1100)
+            +(dyi*c1010+dy*c1110)))
+        +xg/6*(
+            dzi*(
+                dxi3dx*(dyi*c0001+dy*c0101)
+                +dx3dx*(dyi*c0011+dy*c0111))
+            +dz*(
+                dxi3dx*(dyi*c1001  +dy*c1101)
+                +dx3dx*(dyi*c1011+dy*c1111)))
+        +xgi*yg2/6*(
+            dzi*(
+                -(dyi3*c0002+dy3*c0102)
+                +(dyi3*c0012+dy3*c0112))
+            +dz*(
+                -(dyi3*c1002+dy3*c1102)
+                +(dyi3*c1012+dy3*c1112)))
+        +xgi*zg2/6*(
+            dzi3*(
+                -(dyi*c0003+dy*c0103)
+                +(dyi*c0013+dy*c0113))
+            +dz3*(
+                -(dyi*c1003+dy*c1103)
+                +(dyi*c1013+dy*c1113)))
+        +xg*yg2/36*(
+            dzi*(
+                dxi3dx*(dyi3*c0004+dy3*c0104)
+                +dx3dx*(dyi3*c0014+dy3*c0114))
+            +dz*(
+                dxi3dx*(dyi3*c1004+dy3*c1104)
+                +dx3dx*(dyi3*c1014+dy3*c1114)))
+        +xg*zg2/36*(
+            dzi3*(
+                dxi3dx*(dyi*c0005+dy*c0105)
+                +dx3dx*(dyi*c0015+dy*c0115))
+            +dz3*(
+                dxi3dx*(dyi*c1005+dy*c1105)
+                +dx3dx*(dyi*c1015+dy*c1115)))
+        +xgi*yg2*zg2/36*(
+            dzi3*(
+                -(dyi3*c0006+dy3*c0106)
+                +(dyi3*c0016+dy3*c0116))
+            +dz3*(
+                -(dyi3*c1006+dy3*c1106)
+                +(dyi3*c1016+dy3*c1116)))
+        +xg*yg2*zg2/216*(
+            dzi3*(
+                dxi3dx*(dyi3*c0007+dy3*c0107)
+                +dx3dx*(dyi3*c0017+dy3*c0117))
+            +dz3*(
+                dxi3dx*(dyi3*c1007+dy3*c1107)
+                +dx3dx*(dyi3*c1017+dy3*c1117)));
+
+    /* df/dy */
+    f_df[2] = ygi*(
+        dzi*(
+            dxi*(-c0000+c0100)
+            +dx*(-c0010+c0110))
+        +dz*(
+            dxi*(-c1000+c1100)
+            +dx*(-c1010+c1110)))
+        +ygi*xg2/6*(
+            dzi*(
+                dxi3*(-c0001+c0101)
+                +dx3*(-c0011+c0111))
+            +dz*(
+                dxi3*(-c1001+c1101)
+                +dx3*(-c1011+c1111)))
+        +yg/6*(
+            dzi*(
+                dxi*(dyi3dy*c0002+dy3dy*c0102)
+                +dx*(dyi3dy*c0012+dy3dy*c0112))
+            +dz*(
+                dxi*(dyi3dy*c1002+dy3dy*c1102)
+                +dx*(dyi3dy*c1012+dy3dy*c1112)))
+        +ygi*zg2/6*(
+            dzi3*(
+                dxi*(-c0003+c0103)
+                +dx*(-c0013+c0113))
+            +dz3*(
+                dxi*(-c1003+c1103)
+                +dx*(-c1013+c1113)))
+        +xg2*yg/36*(
+            dzi*(
+                dxi3*(dyi3dy*c0004+dy3dy*c0104)
+                +dx3*(dyi3dy*c0014+dy3dy*c0114))
+            +dz*(
+                dxi3*(dyi3dy*c1004+dy3dy*c1104)
+                +dx3*(dyi3dy*c1014+dy3dy*c1114)))
+        +ygi*xg2*zg2/36*(
+            dzi3*(
+                dxi3*(-c0005+c0105)
+                +dx3*(-c0015+c0115))
+            +dz3*(
+                dxi3*(-c1005+c1105)
+                +dx3*(-c1015+c1115)))
+        +yg*zg2/36*(
+            dzi3*(
+                dxi*(dyi3dy*c0006+dy3dy*c0106)
+                +dx*(dyi3dy*c0016+dy3dy*c0116))
+            +dz3*(
+                dxi*(dyi3dy*c1006+dy3dy*c1106)
+                +dx*(dyi3dy*c1016+dy3dy*c1116)))
+        +xg2*yg*zg2/216*(
+            dzi3*(
+                dxi3*(dyi3dy*c0007+dy3dy*c0107)
+                +dx3*(dyi3dy*c0017+dy3dy*c0117))
+            +dz3*(
+                dxi3*(dyi3dy*c1007+dy3dy*c1107)
+                +dx3*(dyi3dy*c1017+dy3dy*c1117)));
+
+    /* df/dz */
+    f_df[3] = zgi*(
+        -(
+            dxi*(dyi*c0000+dy*c0100)
+            +dx*(dyi*c0010+dy*c0110))
+        +(
+            dxi*(dyi*c1000+dy*c1100)
+            +dx*(dyi*c1010+dy*c1110)))
+        +xg2*zgi/6*(
+            -(
+                dxi3*(dyi*c0001+dy*c0101)
+                +dx3*(dyi*c0011+dy*c0111))
+            +(
+                dxi3*(dyi*c1001+dy*c1101)
+                +dx3*(dyi*c1011+dy*c1111)))
+        +yg2*zgi/6*(
+            -(
+                dxi*(dyi3*c0002+dy3*c0102)
+                +dx*(dyi3*c0012+dy3*c0112))
+            +(
+                dxi*(dyi3*c1002+dy3*c1102)
+                +dx*(dyi3*c1012+dy3*c1112)))
+        +zg/6*(
+            dzi3dz*(
+                dxi*(dyi*c0003+dy*c0103)
+                +dx*(dyi*c0013+dy*c0113))
+            +dz3dz*(
+                dxi*(dyi*c1003+dy*c1103)
+                +dx*(dyi*c1013+dy*c1113)))
+        +xg2*yg2*zgi/36*(
+            -(
+                dxi3*(dyi3*c0004+dy3*c0104)
+                +dx3*(dyi3*c0014+dy3*c0114))
+            +(
+                dxi3*(dyi3*c1004+dy3*c1104)
+                +dx3*(dyi3*c1014+dy3*c1114)))
+        +xg2*zg/36*(
+            dzi3dz*(
+                dxi3*(dyi*c0005+dy*c0105)
+                +dx3*(dyi*c0015+dy*c0115))
+            +dz3dz*(
+                dxi3*(dyi*c1005+dy*c1105)
+                +dx3*(dyi*c1015+dy*c1115)))
+        +yg2*zg/36*(
+            dzi3dz*(
+                dxi*(dyi3*c0006+dy3*c0106)
+                +dx*(dyi3*c0016+dy3*c0116))
+            +dz3dz*(
+                dxi*(dyi3*c1006+dy3*c1106)
+                +dx*(dyi3*c1016+dy3*c1116)))
+        +xg2*yg2*zg/216*(
+            dzi3dz*(
+                dxi3*(dyi3*c0007+dy3*c0107)
+                +dx3*(dyi3*c0017+dy3*c0117))
+            +dz3dz*(
+                dxi3*(dyi3*c1007+dy3*c1107)
+                +dx3*(dyi3*c1017+dy3*c1117)));
+    }
+
+    return err;
+}
+
+/**
  * @brief Evaluate interpolated value of 3D field and 1st and 2nd derivatives
  *
  * This function evaluates the interpolated value of a 3D scalar field and
@@ -451,8 +876,8 @@ a5err interp3Dcomp_eval_f(real* f, interp3D_data* str, real x, real y, real z) {
  *
  * @return zero on success and one if (x,y,z) point is outside the grid.
  */
-a5err interp3Dcomp_eval_df(real* f_df, interp3D_data* str,
-                         real x, real y, real z) {
+a5err interp3Dcomp_eval_ddf(real* f_df, interp3D_data* str,
+                            real x, real y, real z) {
 
     /* Make sure periodic coordinates are within [min, max] region. */
     if(str->bc_x == PERIODICBC) {


### PR DESCRIPTION
Implements the change discussed in #224. Please read that issue's latest comment first — it
carries the measurements, the controls, and a correction to a claim I made in the original
issue text.

## What

`B_3DS_eval_B` and `B_3DS_eval_B_dB` evaluated B_r, B_phi and B_z with three independent calls
to `interp3Dcomp_eval_f` / `interp3Dcomp_eval_df`. The three splines share a grid, so each call
repeated the same cell-index arithmetic and the same set of tricubic basis polynomials; only
the coefficient array differed.

Two commits:

1. **Extract the basis and the sum into shared helpers.** The prologue (periodic wrap, cell
   search, basis polynomials, boundary checks) and the tricubic accumulation each move into a
   file-local `static inline` helper, and the existing `interp3Dcomp_eval_f` /
   `interp3Dcomp_eval_df` become thin wrappers over them. Pure code motion — the accumulation
   text is byte-identical to what it replaces, and the helper reads coefficients through the
   spline struct exactly as before, so no operand, operator or parenthesis changed.
2. **Add fused evaluators and use them.** `interp3Dcomp_eval_f3` / `interp3Dcomp_eval_df3`
   build the basis once and then call the accumulation helper three times, explicitly, once per
   component. `eval_df3` writes the `B_dB[12]` layout directly.

The tricubic sum now exists in exactly one place per family rather than being duplicated, which
is what makes the numerical equivalence structural instead of something maintained by hand.

## Results

Single H200 (cc90), 1 rank, `OMP_NUM_THREADS=1`, NVHPC 26.3, `-O2` no fastmath. B_3DS
guiding-centre fixed-step deck, 1M markers, ABBA-interleaved in one job on one node, two runs
per arm (same-arm spread 0.02–0.17 % on the internal timer):

| build | wall (s) | internal (s) | vs develop |
|---|---|---|---|
| `develop` @ d8c21ec | 243.83 | 233.79 | — |
| commit 1 only | 243.97 | 233.70 | 1.00x |
| **this PR** | **196.84** | **187.25** | **1.24x wall / 1.25x internal** |

About 1.16x on a 5000-marker deck (one run per arm, indicative) — the benefit is
workload-dependent and 1.24x should not be read as a universal figure.

## Numerics

Endstate output is **bit-identical** to `develop` for all 1 000 000 markers on every physics
field, established twice independently, with same-binary determinism controls passing for the
unmodified, commit-1-only and fused builds. End-condition census unchanged
(792357 / 207640 / 3 both / 0 aborted).

Commit 1 being bit-identical is the load-bearing check for everything the fusion does not
touch: after the fusion `B_3DS` no longer calls the single-component evaluators, so that build
is what exercises the refactored `interp3Dcomp_eval_f` / `eval_df` bodies which `B_STS` and
`asigma_loc` still use. Those two callers were not themselves executed — no deck here drives
them — so the evidence is that the shared body is numerically inert, not a direct run of them.

I would not have predicted bit-identity from reading the source. An earlier form of this
change, which looped over the three components instead of writing them out, was *not* bitwise
reproducible despite byte-identical arithmetic text (21 markers in 1e6, up to 9.6e-10
relative), because `nvc` left the loop rolled and contracted it differently. That variant is
about 1.41x instead of 1.24x. If you would prefer the speed over exact reproducibility it is a
small change and I am happy to submit it instead — #224 has both sets of numbers.

## Non-GPU builds

The helpers are declared with the SIMD-uniform annotation the public evaluators already carry,
and marked always-inline. That second part is load-bearing rather than cosmetic: at `-O2` the
helper bodies exceed gcc's inlining size limits, and once a helper is left out of line the
caller's SIMD clone degenerates into a per-lane scalar call. Measured on the generated
4-wide AVX clones with gcc 11.5 at the Makefile's CPU flags, the `eval_f` clone goes
517 -> 65 -> 508 instructions across unmodified / naive extraction / this PR, and `eval_df`
1140 -> 65 -> 1131; `interp3Dcomp.o` `.text` returns to within 0.1 % of its original size. The
effect does not appear at `-O3`, which is why it is easy to miss.

The device code is unaffected by that annotation — SASS is identical with and without it — so
the GPU numbers above stand.

## Scope

`B_3DS` only, guiding-centre fixed-step, single GPU. `B_STS` has the same three-call pattern on
a shared grid and could adopt these helpers, but it also interpolates `psi` with a 3D spline on
a *different* grid, so it needs a same-grid check at its own call sites; I left it out rather
than guess at the right shape. A `interp3Dcomp_same_grid` helper is included and used at
`B_3DS_init` (host side, once per run) so the precondition is checked rather than assumed.

## Notes

- Prior art acknowledged in #224: PR #211 (@seanyeh77) proposed the same fusion idea against
  `main` and was closed. This was developed independently; I am happy to coordinate or defer to
  whichever version you prefer.
- The OpenACC GPU flavour of `develop` does not currently link (#226), so that fix needs to be
  present to build and run this in the configuration measured above.
- Found while rebasing our NTHU ISC26 Student Cluster Competition work onto current `develop`
  (same effort as #221/#222/#226/#227).
